### PR TITLE
Add and standardize paranext-core scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,10 @@
     "bump-versions": "ts-node ./lib/bump-versions.ts",
     "test": "jest",
     "test:coverage": "jest --coverage",
-    "core:start": "cd ../paranext-core && npm run start",
-    "core:pull": "git -C ../paranext-core pull --ff-only",
+    "core:start": "npm --prefix ../paranext-core start",
+    "core:stop": "npm --prefix ../paranext-core stop",
     "core:install": "npm --prefix ../paranext-core install",
+    "core:pull": "git -C ../paranext-core pull --ff-only",
     "core:update": "npm run core:pull && npm run core:install"
   },
   "browserslist": [],

--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
     "zip": "zip-build dist release --template '%NAME%_%VERSION%.%EXT%' --override",
     "package": "npm run build:production && npm run zip",
     "package:debug": "cross-env DEBUG_PROD=true npm run package",
-    "start:core": "cd ../paranext-core && npm run start",
-    "start": "cross-env MAIN_ARGS=\"--extensions $INIT_CWD/dist\" concurrently \"npm:watch\" \"npm:start:core\"",
-    "start:production": "cross-env MAIN_ARGS=\"--extensions $INIT_CWD/dist\" concurrently \"npm:watch:production\" \"npm:start:core\"",
+    "start": "cross-env MAIN_ARGS=\"--extensions $INIT_CWD/dist\" concurrently \"npm:watch\" \"npm:core:start\"",
+    "start:production": "cross-env MAIN_ARGS=\"--extensions $INIT_CWD/dist\" concurrently \"npm:watch:production\" \"npm:core:start\"",
     "lint": "npm run lint:scripts && npm run lint:styles && npm run lint:typecheck",
     "lint:scripts": "cross-env NODE_ENV=development eslint --ext .cjs,.js,.jsx,.ts,.tsx --cache .",
     "lint:styles": "stylelint **/*.{css,scss} --allow-empty-input",
@@ -29,7 +28,11 @@
     "lint-fix:scripts": "npm run format && npm run lint:scripts",
     "bump-versions": "ts-node ./lib/bump-versions.ts",
     "test": "jest",
-    "test:coverage": "jest --coverage"
+    "test:coverage": "jest --coverage",
+    "core:start": "cd ../paranext-core && npm run start",
+    "core:pull": "git -C ../paranext-core pull --ff-only",
+    "core:install": "npm --prefix ../paranext-core install",
+    "core:update": "npm run core:pull && npm run core:install"
   },
   "browserslist": [],
   "peerDependencies": {


### PR DESCRIPTION
My paranext-core repo was way out of date, so `npm install` in the extension repo messed with the package lock file.

It felt awkward to have to switch directories in order to update the paranext-core repo, so good ol' AI added some useful scripts for me/us.

It made sense to prefix them all with `core:`, which made `start:core` an exception, so I flipped it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/9)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated and reorganized development scripts for improved management of build processes and core dependency operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->