### PR TITLE
Add script to remove temp/cache dirs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -171,7 +171,7 @@ module.exports = {
       },
     },
     {
-      files: ['./lib/*', './webpack/*'],
+      files: ['./lib/*', './scripts/*', './webpack/*'],
       rules: {
         // These files are scripts not running in Platform.Bible, so they can't use the logger
         'no-console': 'off',

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "test:coverage": "jest --coverage",
     "core:start": "npm --prefix ../paranext-core start",
     "core:stop": "npm --prefix ../paranext-core stop",
+    "core:reset": "npm run core:stop && node ./scripts/delete-temp-dirs.cjs --core --ext",
     "core:install": "npm --prefix ../paranext-core install",
     "core:pull": "git -C ../paranext-core pull --ff-only",
     "core:update": "npm run core:pull && npm run core:install"

--- a/scripts/delete-temp-dirs.cjs
+++ b/scripts/delete-temp-dirs.cjs
@@ -5,7 +5,7 @@ const path = require('path');
 
 // Define directory lists
 const CORE_DIRS = [
-  () => path.join(process.env.APPDATA || '', 'Electron'),
+  () => (process.env.APPDATA ? path.join(process.env.APPDATA, 'Electron') : ''),
   path.join(__dirname, '..', '..', 'paranext-core', 'dev-appdata'),
 ];
 

--- a/scripts/delete-temp-dirs.cjs
+++ b/scripts/delete-temp-dirs.cjs
@@ -7,16 +7,18 @@ const path = require('path');
 const CORE_DIRS = [
   () => {
     /* eslint-disable no-nested-ternary */
-    const electronParent =
-      process.platform === 'win32'
-        ? process.env.APPDATA
-        : process.platform === 'linux'
-          ? path.join(process.env.XDG_CONFIG_HOME || path.join(process.env.HOME || '~', '.config'))
+    let electronParent =
+      process.platform === 'win32' ? process.env.APPDATA : process.env.XDG_CONFIG_HOME;
+    if (!electronParent && process.env.HOME) {
+      electronParent =
+        process.platform === 'linux'
+          ? path.join(process.env.HOME, '.config')
           : process.platform === 'darwin'
-            ? path.join(process.env.HOME || '~', 'Library', 'Application Support')
-            : undefined;
+            ? path.join(process.env.HOME, 'Library', 'Application Support')
+            : '';
+    }
     /* eslint-enable no-nested-ternary */
-    return electronParent ? path.join(electronParent, 'Electron') : undefined;
+    return electronParent ? path.join(electronParent, 'Electron') : '';
   },
   path.join(__dirname, '..', '..', 'paranext-core', 'dev-appdata'),
 ];
@@ -30,7 +32,7 @@ const EXT_DIRS = [
 /**
  * Delete a directory if it exists
  *
- * @param {string} dirPath - The directory path to delete
+ * @param {string | (() => string)} dirPath - The directory path to delete
  */
 function deleteDirectory(dirPath) {
   // Handle functions that generate paths (e.g., for environment variables)

--- a/scripts/delete-temp-dirs.cjs
+++ b/scripts/delete-temp-dirs.cjs
@@ -5,7 +5,19 @@ const path = require('path');
 
 // Define directory lists
 const CORE_DIRS = [
-  () => (process.env.APPDATA ? path.join(process.env.APPDATA, 'Electron') : ''),
+  () => {
+    /* eslint-disable no-nested-ternary */
+    const electronParent =
+      process.platform === 'win32'
+        ? process.env.APPDATA
+        : process.platform === 'linux'
+          ? path.join(process.env.XDG_CONFIG_HOME || path.join(process.env.HOME || '~', '.config'))
+          : process.platform === 'darwin'
+            ? path.join(process.env.HOME || '~', 'Library', 'Application Support')
+            : undefined;
+    /* eslint-enable no-nested-ternary */
+    return electronParent ? path.join(electronParent, 'Electron') : undefined;
+  },
   path.join(__dirname, '..', '..', 'paranext-core', 'dev-appdata'),
 ];
 

--- a/scripts/delete-temp-dirs.cjs
+++ b/scripts/delete-temp-dirs.cjs
@@ -1,25 +1,33 @@
 const fs = require('fs');
 const path = require('path');
 
-/** Cross-platform script to delete temporary and cache directories */
+/**
+ * Cross-platform script to delete temporary and cache directories. Run this if Platform.Bible is
+ * holding on to outdated resources, such as localization strings, project data, or WebView ids.
+ *
+ * Warning: The `--core` flag will delete:
+ *
+ * - The `Electron/` cache directory, which holds the cache for all Electron apps that don't have a
+ *   `name` or `productName` specified in their `package.json`.
+ * - `paranext-core/dev-appdata/`, which includes `installed-extensions/`.
+ */
 
 // Define directory lists
+
+let electronParent =
+  process.platform === 'win32' ? process.env.APPDATA : process.env.XDG_CONFIG_HOME;
+if (!electronParent && process.env.HOME) {
+  electronParent =
+    // eslint-disable-next-line no-nested-ternary
+    process.platform === 'linux'
+      ? path.join(process.env.HOME, '.config')
+      : process.platform === 'darwin'
+        ? path.join(process.env.HOME, 'Library', 'Application Support')
+        : '';
+}
+
 const CORE_DIRS = [
-  () => {
-    /* eslint-disable no-nested-ternary */
-    let electronParent =
-      process.platform === 'win32' ? process.env.APPDATA : process.env.XDG_CONFIG_HOME;
-    if (!electronParent && process.env.HOME) {
-      electronParent =
-        process.platform === 'linux'
-          ? path.join(process.env.HOME, '.config')
-          : process.platform === 'darwin'
-            ? path.join(process.env.HOME, 'Library', 'Application Support')
-            : '';
-    }
-    /* eslint-enable no-nested-ternary */
-    return electronParent ? path.join(electronParent, 'Electron') : '';
-  },
+  electronParent ? path.join(electronParent, 'Electron') : '',
   path.join(__dirname, '..', '..', 'paranext-core', 'dev-appdata'),
 ];
 
@@ -32,28 +40,27 @@ const EXT_DIRS = [
 /**
  * Delete a directory if it exists
  *
- * @param {string | (() => string)} dirPath - The directory path to delete
+ * @param {string} dirPath - The directory path to delete
  */
 function deleteDirectory(dirPath) {
-  // Handle functions that generate paths (e.g., for environment variables)
-  const resolvedPath = typeof dirPath === 'function' ? dirPath() : dirPath;
-
-  if (!resolvedPath) {
-    console.log('⊘ Path could not be resolved');
+  if (!dirPath) {
+    console.log('⊘ Skipping empty path');
     return;
   }
 
   try {
-    if (fs.existsSync(resolvedPath)) {
-      fs.rmSync(resolvedPath, { recursive: true, force: true });
-      console.log(`✓ Deleted ${resolvedPath}`);
+    if (fs.existsSync(dirPath)) {
+      fs.rmSync(dirPath, { recursive: true, force: true });
+      console.log(`✓ Deleted ${dirPath}`);
     } else {
-      console.log(`⊘ ${resolvedPath} does not exist`);
+      console.log(`⊘ ${dirPath} does not exist`);
     }
   } catch (error) {
-    console.error(`✗ Failed to delete ${resolvedPath}:`, error.message);
+    console.error(`✗ Failed to delete ${dirPath}:`, error.message);
   }
 }
+
+// Delete directories based on command-line flags
 
 try {
   const hasCoreFlag = process.argv.includes('--core');

--- a/scripts/delete-temp-dirs.cjs
+++ b/scripts/delete-temp-dirs.cjs
@@ -5,11 +5,8 @@ const path = require('path');
  * Cross-platform script to delete temporary and cache directories. Run this if Platform.Bible is
  * holding on to outdated resources, such as localization strings, project data, or WebView ids.
  *
- * Warning: The `--core` flag will delete:
- *
- * - The `Electron/` cache directory, which holds the cache for all Electron apps that don't have a
- *   `name` or `productName` specified in their `package.json`.
- * - `paranext-core/dev-appdata/`, which includes `installed-extensions/`.
+ * Warning: One directory deleted with the `--core` flag is `paranext-core/dev-appdata/`, which
+ * includes `installed-extensions/`.
  */
 
 // Define directory lists
@@ -27,7 +24,7 @@ if (!electronParent && process.env.HOME) {
 }
 
 const CORE_DIRS = [
-  electronParent ? path.join(electronParent, 'Electron') : '',
+  electronParent ? path.join(electronParent, 'Platform.Bible') : '',
   path.join(__dirname, '..', '..', 'paranext-core', 'dev-appdata'),
 ];
 

--- a/scripts/delete-temp-dirs.cjs
+++ b/scripts/delete-temp-dirs.cjs
@@ -1,0 +1,70 @@
+const fs = require('fs');
+const path = require('path');
+
+/** Cross-platform script to delete temporary and cache directories */
+
+// Define directory lists
+const CORE_DIRS = [
+  () => path.join(process.env.APPDATA || '', 'Electron'),
+  path.join(__dirname, '..', '..', 'paranext-core', 'dev-appdata'),
+];
+
+const EXT_DIRS = [
+  path.join(__dirname, '..', 'coverage'),
+  path.join(__dirname, '..', 'dist'),
+  path.join(__dirname, '..', 'src', 'temp-build'),
+];
+
+/**
+ * Delete a directory if it exists
+ *
+ * @param {string} dirPath - The directory path to delete
+ */
+function deleteDirectory(dirPath) {
+  // Handle functions that generate paths (e.g., for environment variables)
+  const resolvedPath = typeof dirPath === 'function' ? dirPath() : dirPath;
+
+  if (!resolvedPath) {
+    console.log('⊘ Path could not be resolved');
+    return;
+  }
+
+  try {
+    if (fs.existsSync(resolvedPath)) {
+      fs.rmSync(resolvedPath, { recursive: true, force: true });
+      console.log(`✓ Deleted ${resolvedPath}`);
+    } else {
+      console.log(`⊘ ${resolvedPath} does not exist`);
+    }
+  } catch (error) {
+    console.error(`✗ Failed to delete ${resolvedPath}:`, error.message);
+  }
+}
+
+try {
+  const hasCoreFlag = process.argv.includes('--core');
+  const hasExtFlag = process.argv.includes('--ext');
+
+  if (!hasCoreFlag && !hasExtFlag) {
+    console.error('Usage: node delete-temp-dirs.cjs [--core] [--ext]');
+    console.error('  --core  Delete AppData and core cache directories (Electron, dev-appdata)');
+    console.error('  --ext   Delete extension directories (coverage, dist, src/temp-build)');
+    process.exit(1);
+  }
+
+  if (hasCoreFlag) {
+    console.log('Deleting core cache directories...');
+    CORE_DIRS.forEach(deleteDirectory);
+  }
+
+  if (hasExtFlag) {
+    console.log('Deleting extension directories...');
+    EXT_DIRS.forEach(deleteDirectory);
+  }
+
+  console.log('Complete!');
+  process.exit(0);
+} catch (error) {
+  console.error('Error during cleanup:', error);
+  process.exit(1);
+}

--- a/scripts/delete-temp-dirs.cjs
+++ b/scripts/delete-temp-dirs.cjs
@@ -11,17 +11,22 @@ const path = require('path');
 
 // Define directory lists
 
+/* eslint-disable no-nested-ternary */
 let electronParent =
-  process.platform === 'win32' ? process.env.APPDATA : process.env.XDG_CONFIG_HOME;
+  process.platform === 'win32'
+    ? process.env.APPDATA
+    : process.platform === 'linux'
+      ? process.env.XDG_CONFIG_HOME
+      : '';
 if (!electronParent && process.env.HOME) {
   electronParent =
-    // eslint-disable-next-line no-nested-ternary
     process.platform === 'linux'
       ? path.join(process.env.HOME, '.config')
       : process.platform === 'darwin'
         ? path.join(process.env.HOME, 'Library', 'Application Support')
         : '';
 }
+/* eslint-enable no-nested-ternary */
 
 const CORE_DIRS = [
   electronParent ? path.join(electronParent, 'Platform.Bible') : '',

--- a/scripts/delete-temp-dirs.cjs
+++ b/scripts/delete-temp-dirs.cjs
@@ -5,8 +5,10 @@ const path = require('path');
  * Cross-platform script to delete temporary and cache directories. Run this if Platform.Bible is
  * holding on to outdated resources, such as localization strings, project data, or WebView ids.
  *
- * Warning: One directory deleted with the `--core` flag is `paranext-core/dev-appdata/`, which
- * includes `installed-extensions/`.
+ * Warning: The `--core` flag deletes:
+ *
+ * - The `Electron` cache folder, which affect any other Electron apps
+ * - `paranext-core/dev-appdata/`, which includes `installed-extensions/`
  */
 
 // Define directory lists
@@ -29,7 +31,7 @@ if (!electronParent && process.env.HOME) {
 /* eslint-enable no-nested-ternary */
 
 const CORE_DIRS = [
-  electronParent ? path.join(electronParent, 'Platform.Bible') : '',
+  electronParent ? path.join(electronParent, 'Electron') : '',
   path.join(__dirname, '..', '..', 'paranext-core', 'dev-appdata'),
 ];
 

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "allowJs": true
   },
-  "include": [".eslintrc.js", "*.ts", "*.js", "lib", "src", "webpack"]
+  "include": ["*.js", "*.ts", "lib", "scripts", "src", "webpack"]
 }

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "allowJs": true
   },
-  "include": ["*.js", "*.ts", "lib", "scripts", "src", "webpack"]
+  "include": [".*.js", "*.js", "*.ts", "lib", "scripts", "src", "webpack"]
 }


### PR DESCRIPTION
Tested in Powershell on Windows 11. Not tested on Unix.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/58)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `core:reset` command to clean core caches and temp directories.
  * Added a CLI cleanup utility to remove core and extension temporary/build artifacts.

* **Chores**
  * Broadened linting to include script files.
  * Relaxed specific lint rules for additional script locations to accommodate tooling scripts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sillsdev/interlinearizer-extension/pull/58)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->