### PR TITLE
Split modals into separate component

### DIFF
--- a/src/__tests__/components/InterlinearizerLoader.test.tsx
+++ b/src/__tests__/components/InterlinearizerLoader.test.tsx
@@ -123,14 +123,20 @@ jest.mock('../../components/ProjectMetadataModal', () => ({
       <button
         type="button"
         data-testid="metadata-modal-saved"
-        onClick={() => onProjectSaved({ analysisWritingSystem: 'fr' })}
+        onClick={() => {
+          onProjectSaved({ analysisWritingSystem: 'fr' });
+          onClose();
+        }}
       >
         Save
       </button>
       <button
         type="button"
         data-testid="metadata-modal-deleted"
-        onClick={() => onProjectDeleted(MOCK_PROJECT.id)}
+        onClick={() => {
+          onProjectDeleted(MOCK_PROJECT.id);
+          onClose();
+        }}
       >
         Delete
       </button>

--- a/src/components/InterlinearizerLoader.tsx
+++ b/src/components/InterlinearizerLoader.tsx
@@ -5,28 +5,15 @@ import { TabToolbar } from 'platform-bible-react';
 import type { SelectMenuItemHandler } from 'platform-bible-react';
 import { isPlatformError } from 'platform-bible-utils';
 import { useCallback, useMemo, useState } from 'react';
-import ContinuousScrollToggle from './ContinuousScrollToggle';
-import { CreateProjectModal } from './CreateProjectModal';
-import Interlinearizer from './Interlinearizer';
-import { ProjectMetadataModal } from './ProjectMetadataModal';
-import ScriptureNavControls from './ScriptureNavControls';
-import {
-  SelectInterlinearProjectModal,
-  type InterlinearProjectSummary,
-} from './SelectInterlinearProjectModal';
 import useInterlinearizerBookData from '../hooks/useInterlinearizerBookData';
 import useOptimisticBooleanSetting from '../hooks/useOptimisticBooleanSetting';
+import ContinuousScrollToggle from './ContinuousScrollToggle';
+import Interlinearizer from './Interlinearizer';
+import ProjectModals, { type ModalState } from './ProjectModals';
+import ScriptureNavControls from './ScriptureNavControls';
+import type { ActiveProjectState } from './SelectInterlinearProjectModal';
 
 const STRING_KEYS: `%${string}%`[] = ['%interlinearizer_continuousScrollToggle%'];
-
-/** Which modal is currently visible. Only one can be open at a time. */
-type ModalState = 'none' | 'select' | 'create' | 'metadata';
-
-/** Fields of the active interlinear project persisted in WebView state. */
-type ActiveProjectState = Pick<
-  InterlinearProjectSummary,
-  'id' | 'createdAt' | 'name' | 'description' | 'sourceProjectId' | 'analysisWritingSystem'
->;
 
 /**
  * Root component for loading the Interlinearizer. Loads book data and settings, manages modal state
@@ -73,31 +60,10 @@ export default function InterlinearizerLoader({
    * restores. Updated after creation and when the user selects an existing project from the
    * picker.
    */
-  const [activeProject, setActiveProject, resetActiveProject] = useWebViewState<
-    ActiveProjectState | undefined
-  >('activeProject', undefined);
-
-  /**
-   * The project currently open in the metadata modal. Set when the user clicks the info icon in the
-   * select modal or triggers "View Project Info" from the menu.
-   */
-  const [metadataProject, setMetadataProject] = useState<InterlinearProjectSummary | undefined>(
+  const [activeProject] = useWebViewState<ActiveProjectState | undefined>(
+    'activeProject',
     undefined,
   );
-
-  /**
-   * Tracks where the metadata modal was opened from so the correct modal is restored on close.
-   * `'select'` means it was opened via the info icon in the select modal; `'menu'` means it was
-   * opened via the "View Project Info" menu item.
-   */
-  const [metadataSource, setMetadataSource] = useState<'select' | 'menu'>('menu');
-
-  /**
-   * Tracks where the create modal was opened from so the correct modal is restored on close.
-   * `'select'` means it was opened via "New Interlinear Project..." in the select modal; `'menu'`
-   * means it was opened directly from the top menu.
-   */
-  const [createSource, setCreateSource] = useState<'select' | 'menu'>('menu');
 
   /**
    * Routes top-menu commands to the appropriate modal. `openSelectProjectModal` opens the select
@@ -111,77 +77,14 @@ export default function InterlinearizerLoader({
       if (item.command === 'interlinearizer.openSelectProjectModal') {
         setModal('select');
       } else if (item.command === 'interlinearizer.openNewProjectModal') {
-        setCreateSource('menu');
         setModal('create');
       } else if (item.command === 'interlinearizer.openProjectInfoModal') {
         if (activeProject) {
-          setMetadataProject(activeProject);
-          setMetadataSource('menu');
           setModal('metadata');
         }
       }
     },
     [activeProject],
-  );
-
-  /**
-   * Opens the metadata modal for the project whose info icon was clicked in the select modal.
-   *
-   * @param project - The project to display in the metadata modal.
-   */
-  const handleViewInfo = useCallback((project: InterlinearProjectSummary) => {
-    setMetadataProject(project);
-    setMetadataSource('select');
-    setModal('metadata');
-  }, []);
-
-  /**
-   * Records a newly created interlinear project as the active project.
-   *
-   * @param project - The full persisted project returned by the create command.
-   */
-  const handleProjectCreated = useCallback(
-    (project: InterlinearProjectSummary) => {
-      setActiveProject(project);
-    },
-    [setActiveProject],
-  );
-
-  /** Closes the create modal, returning to the select modal if creation was initiated from there. */
-  const handleCreateModalClose = useCallback(() => {
-    setModal(createSource === 'select' ? 'select' : 'none');
-  }, [createSource]);
-
-  /**
-   * Called when the metadata modal saves changes. Updates `activeProject` state when the edited
-   * project is the currently active one, then returns to the appropriate modal.
-   *
-   * @param updated - The updated name, description, and analysisWritingSystem.
-   */
-  const handleMetadataProjectSaved = useCallback(
-    (updated: { name?: string; description?: string; analysisWritingSystem: string }) => {
-      if (activeProject && metadataProject?.id === activeProject.id) {
-        setActiveProject({ ...activeProject, ...updated });
-      }
-      setModal(metadataSource === 'select' ? 'select' : 'none');
-      setMetadataProject(undefined);
-    },
-    [activeProject, metadataProject, metadataSource, setActiveProject],
-  );
-
-  /**
-   * Called when the metadata modal deletes the project. Clears `activeProject` if it was the
-   * deleted project, then returns to the appropriate modal.
-   *
-   * @param deletedId - UUID of the project that was deleted.
-   */
-  const handleMetadataProjectDeleted = useCallback(
-    (deletedId: string) => {
-      if (activeProject?.id === deletedId) resetActiveProject();
-      setModal(metadataSource === 'select' ? 'select' : 'none');
-      setMetadataProject(undefined);
-    },
-    [activeProject, metadataSource, resetActiveProject],
   );
 
   /**
@@ -273,46 +176,12 @@ export default function InterlinearizerLoader({
         />
       )}
 
-      {modal === 'select' && (
-        <SelectInterlinearProjectModal
-          sourceProjectId={projectId}
-          onSelect={(project) => {
-            setActiveProject(project);
-            setModal('none');
-          }}
-          onCreateNew={() => {
-            setCreateSource('select');
-            setModal('create');
-          }}
-          onClose={() => setModal('none')}
-          onViewInfo={handleViewInfo}
-        />
-      )}
-
-      {modal === 'create' && (
-        <CreateProjectModal
-          projectId={projectId}
-          onClose={handleCreateModalClose}
-          onProjectCreated={handleProjectCreated}
-        />
-      )}
-
-      {modal === 'metadata' && metadataProject && (
-        <ProjectMetadataModal
-          interlinearProjectId={metadataProject.id}
-          name={metadataProject.name}
-          description={metadataProject.description}
-          sourceProjectId={metadataProject.sourceProjectId}
-          analysisWritingSystem={metadataProject.analysisWritingSystem}
-          createdAt={metadataProject.createdAt}
-          onClose={() => {
-            setModal(metadataSource === 'select' ? 'select' : 'none');
-            setMetadataProject(undefined);
-          }}
-          onProjectSaved={handleMetadataProjectSaved}
-          onProjectDeleted={handleMetadataProjectDeleted}
-        />
-      )}
+      <ProjectModals
+        modal={modal}
+        projectId={projectId}
+        setModal={setModal}
+        useWebViewState={useWebViewState}
+      />
     </div>
   );
 }

--- a/src/components/InterlinearizerLoader.tsx
+++ b/src/components/InterlinearizerLoader.tsx
@@ -177,6 +177,7 @@ export default function InterlinearizerLoader({
       )}
 
       <ProjectModals
+        activeProject={activeProject}
         modal={modal}
         projectId={projectId}
         setModal={setModal}

--- a/src/components/ProjectModals.tsx
+++ b/src/components/ProjectModals.tsx
@@ -1,5 +1,5 @@
 import type { UseWebViewStateHook } from '@papi/core';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import { CreateProjectModal } from './CreateProjectModal';
 import { ProjectMetadataModal } from './ProjectMetadataModal';
 import {
@@ -16,31 +16,32 @@ export type ModalState = 'none' | 'select' | 'create' | 'metadata';
  * selection, and metadata modals.
  *
  * @param props - Component props
+ * @param props.activeProject - The currently active interlinear project, read from WebView state by
+ *   the parent.
  * @param props.modal - Which modal is currently open
  * @param props.projectId - PAPI project ID passed from the host
  * @param props.setModal - Setter for which modal is open
  * @param props.useWebViewState - Hook for reading and writing values persisted in the WebView's
  *   saved state (survives tab restores)
+ * @returns The currently active modal, or an empty container when no modal is open.
  */
 export default function ProjectModals({
+  activeProject,
   modal,
   projectId,
   setModal,
   useWebViewState,
 }: Readonly<{
+  activeProject: ActiveProjectState | undefined;
   modal: ModalState;
   projectId: string;
   setModal: (modal: ModalState) => void;
   useWebViewState: UseWebViewStateHook;
 }>) {
-  /**
-   * Persisted snapshot of the active interlinear project — kept in WebView state so it survives tab
-   * restores. Updated after creation and when the user selects an existing project from the
-   * picker.
-   */
-  const [activeProject, setActiveProject, resetActiveProject] = useWebViewState<
-    ActiveProjectState | undefined
-  >('activeProject', undefined);
+  const [, setActiveProject, resetActiveProject] = useWebViewState<ActiveProjectState | undefined>(
+    'activeProject',
+    undefined,
+  );
 
   /**
    * The project currently open in the metadata modal. Set when the user clicks the info icon in the
@@ -57,11 +58,13 @@ export default function ProjectModals({
    */
   const [metadataSourceIsSelect, setMetadataSourceIsSelect] = useState(false);
 
-  useEffect(() => {
-    if (modal === 'metadata' && !metadataProject) {
-      setMetadataProject(activeProject);
-    }
-  }, [modal, metadataProject, activeProject]);
+  /**
+   * Tracks whether the create modal was opened from the select modal, so the correct modal is
+   * restored on close.
+   */
+  const [createSourceIsSelect, setCreateSourceIsSelect] = useState(false);
+
+  const resolvedMetadataProject = metadataProject ?? activeProject;
 
   /**
    * Opens the metadata modal for the project whose info icon was clicked in the select modal.
@@ -79,34 +82,30 @@ export default function ProjectModals({
 
   /**
    * Called when the metadata modal saves changes. Updates `activeProject` state when the edited
-   * project is the currently active one, then returns to the appropriate modal.
+   * project is the currently active one.
    *
    * @param updated - The updated name, description, and analysisWritingSystem.
    */
   const handleMetadataProjectSaved = useCallback(
     (updated: { name?: string; description?: string; analysisWritingSystem: string }) => {
-      if (activeProject && metadataProject?.id === activeProject.id) {
+      if (activeProject && resolvedMetadataProject?.id === activeProject.id) {
         setActiveProject({ ...activeProject, ...updated });
       }
-      setModal(metadataSourceIsSelect ? 'select' : 'none');
-      setMetadataProject(undefined);
     },
-    [activeProject, metadataProject, metadataSourceIsSelect, setActiveProject, setModal],
+    [activeProject, resolvedMetadataProject, setActiveProject],
   );
 
   /**
    * Called when the metadata modal deletes the project. Clears `activeProject` if it was the
-   * deleted project, then returns to the appropriate modal.
+   * deleted project.
    *
    * @param deletedId - UUID of the project that was deleted.
    */
   const handleMetadataProjectDeleted = useCallback(
     (deletedId: string) => {
       if (activeProject?.id === deletedId) resetActiveProject();
-      setModal(metadataSourceIsSelect ? 'select' : 'none');
-      setMetadataProject(undefined);
     },
-    [activeProject, metadataSourceIsSelect, resetActiveProject, setModal],
+    [activeProject, resetActiveProject],
   );
 
   return (
@@ -118,7 +117,10 @@ export default function ProjectModals({
             setActiveProject(project);
             setModal('none');
           }}
-          onCreateNew={() => setModal('create')}
+          onCreateNew={() => {
+            setCreateSourceIsSelect(true);
+            setModal('create');
+          }}
           onClose={() => setModal('none')}
           onViewInfo={handleViewInfo}
         />
@@ -127,19 +129,22 @@ export default function ProjectModals({
       {modal === 'create' && (
         <CreateProjectModal
           projectId={projectId}
-          onClose={() => setModal('none')}
+          onClose={() => {
+            setModal(createSourceIsSelect ? 'select' : 'none');
+            setCreateSourceIsSelect(false);
+          }}
           onProjectCreated={setActiveProject}
         />
       )}
 
-      {modal === 'metadata' && metadataProject && (
+      {modal === 'metadata' && resolvedMetadataProject && (
         <ProjectMetadataModal
-          interlinearProjectId={metadataProject.id}
-          name={metadataProject.name}
-          description={metadataProject.description}
-          sourceProjectId={metadataProject.sourceProjectId}
-          analysisWritingSystem={metadataProject.analysisWritingSystem}
-          createdAt={metadataProject.createdAt}
+          interlinearProjectId={resolvedMetadataProject.id}
+          name={resolvedMetadataProject.name}
+          description={resolvedMetadataProject.description}
+          sourceProjectId={resolvedMetadataProject.sourceProjectId}
+          analysisWritingSystem={resolvedMetadataProject.analysisWritingSystem}
+          createdAt={resolvedMetadataProject.createdAt}
           onClose={() => {
             setModal(metadataSourceIsSelect ? 'select' : 'none');
             setMetadataSourceIsSelect(false);

--- a/src/components/ProjectModals.tsx
+++ b/src/components/ProjectModals.tsx
@@ -1,0 +1,154 @@
+import type { UseWebViewStateHook } from '@papi/core';
+import { useCallback, useEffect, useState } from 'react';
+import { CreateProjectModal } from './CreateProjectModal';
+import { ProjectMetadataModal } from './ProjectMetadataModal';
+import {
+  type ActiveProjectState,
+  type InterlinearProjectSummary,
+  SelectInterlinearProjectModal,
+} from './SelectInterlinearProjectModal';
+
+/** Which modal is currently visible. Only one can be open at a time. */
+export type ModalState = 'none' | 'select' | 'create' | 'metadata';
+
+/**
+ * Component for managing project modals in the Interlinearizer. Handles state for project creation,
+ * selection, and metadata modals.
+ *
+ * @param props - Component props
+ * @param props.modal - Which modal is currently open
+ * @param props.projectId - PAPI project ID passed from the host
+ * @param props.setModal - Setter for which modal is open
+ * @param props.useWebViewState - Hook for reading and writing values persisted in the WebView's
+ *   saved state (survives tab restores)
+ */
+export default function ProjectModals({
+  modal,
+  projectId,
+  setModal,
+  useWebViewState,
+}: Readonly<{
+  modal: ModalState;
+  projectId: string;
+  setModal: (modal: ModalState) => void;
+  useWebViewState: UseWebViewStateHook;
+}>) {
+  /**
+   * Persisted snapshot of the active interlinear project — kept in WebView state so it survives tab
+   * restores. Updated after creation and when the user selects an existing project from the
+   * picker.
+   */
+  const [activeProject, setActiveProject, resetActiveProject] = useWebViewState<
+    ActiveProjectState | undefined
+  >('activeProject', undefined);
+
+  /**
+   * The project currently open in the metadata modal. Set when the user clicks the info icon in the
+   * select modal or triggers "View Project Info" from the menu.
+   */
+  const [metadataProject, setMetadataProject] = useState<InterlinearProjectSummary | undefined>(
+    undefined,
+  );
+
+  /**
+   * Tracks where the metadata modal was opened from so the correct modal is restored on close.
+   * `'select'` means it was opened via the info icon in the select modal; `'menu'` means it was
+   * opened via the "View Project Info" menu item.
+   */
+  const [metadataSourceIsSelect, setMetadataSourceIsSelect] = useState(false);
+
+  useEffect(() => {
+    if (modal === 'metadata' && !metadataProject) {
+      setMetadataProject(activeProject);
+    }
+  }, [modal, metadataProject, activeProject]);
+
+  /**
+   * Opens the metadata modal for the project whose info icon was clicked in the select modal.
+   *
+   * @param project - The project to display in the metadata modal.
+   */
+  const handleViewInfo = useCallback(
+    (project: InterlinearProjectSummary) => {
+      setMetadataProject(project);
+      setMetadataSourceIsSelect(true);
+      setModal('metadata');
+    },
+    [setModal],
+  );
+
+  /**
+   * Called when the metadata modal saves changes. Updates `activeProject` state when the edited
+   * project is the currently active one, then returns to the appropriate modal.
+   *
+   * @param updated - The updated name, description, and analysisWritingSystem.
+   */
+  const handleMetadataProjectSaved = useCallback(
+    (updated: { name?: string; description?: string; analysisWritingSystem: string }) => {
+      if (activeProject && metadataProject?.id === activeProject.id) {
+        setActiveProject({ ...activeProject, ...updated });
+      }
+      setModal(metadataSourceIsSelect ? 'select' : 'none');
+      setMetadataProject(undefined);
+    },
+    [activeProject, metadataProject, metadataSourceIsSelect, setActiveProject, setModal],
+  );
+
+  /**
+   * Called when the metadata modal deletes the project. Clears `activeProject` if it was the
+   * deleted project, then returns to the appropriate modal.
+   *
+   * @param deletedId - UUID of the project that was deleted.
+   */
+  const handleMetadataProjectDeleted = useCallback(
+    (deletedId: string) => {
+      if (activeProject?.id === deletedId) resetActiveProject();
+      setModal(metadataSourceIsSelect ? 'select' : 'none');
+      setMetadataProject(undefined);
+    },
+    [activeProject, metadataSourceIsSelect, resetActiveProject, setModal],
+  );
+
+  return (
+    <div>
+      {modal === 'select' && (
+        <SelectInterlinearProjectModal
+          sourceProjectId={projectId}
+          onSelect={(project) => {
+            setActiveProject(project);
+            setModal('none');
+          }}
+          onCreateNew={() => setModal('create')}
+          onClose={() => setModal('none')}
+          onViewInfo={handleViewInfo}
+        />
+      )}
+
+      {modal === 'create' && (
+        <CreateProjectModal
+          projectId={projectId}
+          onClose={() => setModal('none')}
+          onProjectCreated={setActiveProject}
+        />
+      )}
+
+      {modal === 'metadata' && metadataProject && (
+        <ProjectMetadataModal
+          interlinearProjectId={metadataProject.id}
+          name={metadataProject.name}
+          description={metadataProject.description}
+          sourceProjectId={metadataProject.sourceProjectId}
+          analysisWritingSystem={metadataProject.analysisWritingSystem}
+          createdAt={metadataProject.createdAt}
+          onClose={() => {
+            setModal(metadataSourceIsSelect ? 'select' : 'none');
+            setMetadataSourceIsSelect(false);
+            setMetadataProject(undefined);
+          }}
+          onProjectSaved={handleMetadataProjectSaved}
+          onProjectDeleted={handleMetadataProjectDeleted}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/SelectInterlinearProjectModal.tsx
+++ b/src/components/SelectInterlinearProjectModal.tsx
@@ -21,6 +21,12 @@ export type InterlinearProjectSummary = Pick<
   'id' | 'createdAt' | 'sourceProjectId' | 'analysisWritingSystem' | 'name' | 'description'
 >;
 
+/** Fields of the active interlinear project persisted in WebView state. */
+export type ActiveProjectState = Pick<
+  InterlinearProjectSummary,
+  'id' | 'createdAt' | 'name' | 'description' | 'sourceProjectId' | 'analysisWritingSystem'
+>;
+
 /** Type guard for {@link InterlinearProjectSummary} parsed from unknown JSON. */
 export function isInterlinearProjectSummary(p: unknown): p is InterlinearProjectSummary {
   return (


### PR DESCRIPTION
Suggested refactor for #33 

This is what it might look like to have the models handled in their own component. The only change in behavior is that after a project is created via the select-project modal, you don't return to that modal, which I think would be simpler for users anyway.

Note: the tests haven't been updated to match this change.
Also: some of the cross-component types should perhaps be extracted to a common types file.
Devin has a few useful flags as well if this goes through: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/62

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/62)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal organization of project modal management for better code maintainability and clearer separation of concerns.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sillsdev/interlinearizer-extension/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->