### PR TITLE
bugfix and cleanup: opacity hide, doc cleanup, helper functions

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -115,25 +115,64 @@ function findRegisteredHandler(commandName: string): ((...args: unknown[]) => un
 }
 
 /**
- * Activates the extension and returns a typed wrapper around the `interlinearizer.openForWebView`
- * command handler.
+ * Activates the extension with a fresh test context and returns the handler registered for
+ * `commandName`, cast to `T`.
  *
- * @returns A function that invokes the handler with an optional WebView ID and resolves to the
- *   opened WebView ID string, or `undefined` if the handler returns a non-string.
+ * @param commandName - The fully-qualified command name to look up.
+ * @returns The handler registered during `activate()`, cast to `T`.
  * @throws If the handler was not registered during `activate()`.
  */
-async function getOpenForWebViewHandler(): Promise<
-  (webViewId?: string) => Promise<string | undefined>
-> {
+async function activateAndGetHandler<T>(commandName: string): Promise<T> {
   const context = createTestActivationContext();
   await activate(context);
-  const rawHandler = findRegisteredHandler('interlinearizer.openForWebView');
-  if (!rawHandler) throw new Error('Handler not found for interlinearizer.openForWebView');
-  return async (webViewId?: string): Promise<string | undefined> => {
-    const result: unknown = await rawHandler(webViewId);
-    return typeof result === 'string' ? result : undefined;
-  };
+  const rawHandler = findRegisteredHandler(commandName);
+  if (!rawHandler) throw new Error(`Handler not found for ${commandName}`);
+  // eslint-disable-next-line no-type-assertion/no-type-assertion
+  return rawHandler as unknown as T;
 }
+
+/** Activates the extension and returns the `interlinearizer.openForWebView` handler. */
+const getOpenForWebViewHandler = () =>
+  activateAndGetHandler<(webViewId?: string) => Promise<string | undefined>>(
+    'interlinearizer.openForWebView',
+  );
+
+/** Activates the extension and returns the `interlinearizer.createProject` handler. */
+const getCreateProjectHandler = () =>
+  activateAndGetHandler<
+    (sourceProjectId: string, analysisLanguages: string[]) => Promise<string | undefined>
+  >('interlinearizer.createProject');
+
+/** Activates the extension and returns the `interlinearizer.deleteProject` handler. */
+const getDeleteProjectHandler = () =>
+  activateAndGetHandler<(id: string) => Promise<void>>('interlinearizer.deleteProject');
+
+/** Activates the extension and returns the `interlinearizer.getProjectsForSource` handler. */
+const getProjectsForSourceHandler = () =>
+  activateAndGetHandler<(sourceProjectId: string) => Promise<string>>(
+    'interlinearizer.getProjectsForSource',
+  );
+
+/** Activates the extension and returns the `interlinearizer.updateProjectMetadata` handler. */
+const getUpdateProjectMetadataHandler = () =>
+  activateAndGetHandler<
+    (
+      id: string,
+      name: string | undefined,
+      description: string | undefined,
+      analysisLanguages: string[],
+    ) => Promise<string | undefined>
+  >('interlinearizer.updateProjectMetadata');
+
+/** Activates the extension and returns the `interlinearizer.getProject` handler. */
+const getGetProjectHandler = () =>
+  activateAndGetHandler<(id: string) => Promise<string | undefined>>('interlinearizer.getProject');
+
+/** Activates the extension and returns the `interlinearizer.saveAnalysis` handler. */
+const getSaveAnalysisHandler = () =>
+  activateAndGetHandler<(id: string, analysisJson: string) => Promise<void>>(
+    'interlinearizer.saveAnalysis',
+  );
 
 /**
  * Retrieves the callback passed to onDidOpenWebView during the most recent activate() call.
@@ -157,101 +196,6 @@ function getCloseWebViewCallback(): (event: { webView: SavedWebViewDefinition })
   const cb: unknown = __mockOnDidCloseWebView.mock.calls[0]?.[0];
   if (!isCallable(cb)) throw new Error('onDidCloseWebView callback not found');
   return (event) => cb(event);
-}
-
-/**
- * Activates the extension and returns a typed wrapper around the `interlinearizer.createProject`
- * command handler.
- *
- * @returns A function that invokes the handler with a source project ID and analysis languages,
- *   resolving to the JSON-stringified project or `undefined` if the handler returns a non-string.
- * @throws If the handler was not registered during `activate()`.
- */
-async function getCreateProjectHandler(): Promise<
-  (sourceProjectId: string, analysisLanguages: string[]) => Promise<string | undefined>
-> {
-  const context = createTestActivationContext();
-  await activate(context);
-  const rawHandler = findRegisteredHandler('interlinearizer.createProject');
-  if (!rawHandler) throw new Error('Handler not found for interlinearizer.createProject');
-  return async (
-    sourceProjectId: string,
-    analysisLanguages: string[],
-  ): Promise<string | undefined> => {
-    const result: unknown = await rawHandler(sourceProjectId, analysisLanguages);
-    return typeof result === 'string' ? result : undefined;
-  };
-}
-
-/**
- * Activates the extension and returns a typed wrapper around the `interlinearizer.deleteProject`
- * command handler.
- *
- * @returns A function that invokes the handler with a project UUID and resolves when deletion
- *   completes.
- * @throws If the handler was not registered during `activate()`.
- */
-async function getDeleteProjectHandler(): Promise<(id: string) => Promise<void>> {
-  const context = createTestActivationContext();
-  await activate(context);
-  const rawHandler = findRegisteredHandler('interlinearizer.deleteProject');
-  if (!rawHandler) throw new Error('Handler not found for interlinearizer.deleteProject');
-  return async (id: string): Promise<void> => {
-    await rawHandler(id);
-  };
-}
-
-/**
- * Activates the extension and returns a typed wrapper around the
- * `interlinearizer.getProjectsForSource` command handler.
- *
- * @returns A function that invokes the handler with a source project ID and resolves to the
- *   JSON-stringified project array (falls back to `'[]'` if the handler returns a non-string).
- * @throws If the handler was not registered during `activate()`.
- */
-async function getProjectsForSourceHandler(): Promise<
-  (sourceProjectId: string) => Promise<string>
-> {
-  const context = createTestActivationContext();
-  await activate(context);
-  const rawHandler = findRegisteredHandler('interlinearizer.getProjectsForSource');
-  if (!rawHandler) throw new Error('Handler not found for interlinearizer.getProjectsForSource');
-  return async (sourceProjectId: string): Promise<string> => {
-    const result: unknown = await rawHandler(sourceProjectId);
-    return typeof result === 'string' ? result : '[]';
-  };
-}
-
-/**
- * Activates the extension and returns a typed wrapper around the
- * `interlinearizer.updateProjectMetadata` command handler.
- *
- * @returns A function that invokes the handler with a project UUID and updated fields, resolving to
- *   the JSON-stringified updated project or `undefined` if the project was not found or the handler
- *   returns a non-string.
- * @throws If the handler was not registered during `activate()`.
- */
-async function getUpdateProjectMetadataHandler(): Promise<
-  (
-    id: string,
-    name: string | undefined,
-    description: string | undefined,
-    analysisLanguages: string[],
-  ) => Promise<string | undefined>
-> {
-  const context = createTestActivationContext();
-  await activate(context);
-  const rawHandler = findRegisteredHandler('interlinearizer.updateProjectMetadata');
-  if (!rawHandler) throw new Error('Handler not found for interlinearizer.updateProjectMetadata');
-  return async (
-    id: string,
-    name: string | undefined,
-    description: string | undefined,
-    analysisLanguages: string[],
-  ): Promise<string | undefined> => {
-    const result: unknown = await rawHandler(id, name, description, analysisLanguages);
-    return typeof result === 'string' ? result : undefined;
-  };
 }
 
 describe('main', () => {
@@ -876,25 +820,6 @@ describe('main', () => {
     const mockGetProject = jest.mocked(projectStorage.getProject);
     const stubProject = makeStubProject('proj-id');
 
-    /**
-     * Activates the extension and returns a typed wrapper around the `interlinearizer.getProject`
-     * command handler.
-     *
-     * @returns A function that invokes the handler with a project UUID and resolves to the
-     *   JSON-stringified project or `undefined`.
-     * @throws If the handler was not registered during `activate()`.
-     */
-    async function getGetProjectHandler(): Promise<(id: string) => Promise<string | undefined>> {
-      const context = createTestActivationContext();
-      await activate(context);
-      const rawHandler = findRegisteredHandler('interlinearizer.getProject');
-      if (!rawHandler) throw new Error('Handler not found for interlinearizer.getProject');
-      return async (id: string): Promise<string | undefined> => {
-        const result: unknown = await rawHandler(id);
-        return typeof result === 'string' ? result : undefined;
-      };
-    }
-
     it('registers the interlinearizer.getProject command', async () => {
       const context = createTestActivationContext();
 
@@ -944,25 +869,6 @@ describe('main', () => {
       ...emptyAnalysis(),
       tokenAnalyses: [{ id: 'ta-1', surfaceText: 'In', gloss: { en: 'in' } }],
     };
-
-    /**
-     * Activates the extension and returns a typed wrapper around the `interlinearizer.saveAnalysis`
-     * command handler.
-     *
-     * @returns A function that invokes the handler with a project UUID and analysis JSON.
-     * @throws If the handler was not registered during `activate()`.
-     */
-    async function getSaveAnalysisHandler(): Promise<
-      (id: string, analysisJson: string) => Promise<void>
-    > {
-      const context = createTestActivationContext();
-      await activate(context);
-      const rawHandler = findRegisteredHandler('interlinearizer.saveAnalysis');
-      if (!rawHandler) throw new Error('Handler not found for interlinearizer.saveAnalysis');
-      return async (id: string, analysisJson: string): Promise<void> => {
-        await rawHandler(id, analysisJson);
-      };
-    }
 
     it('registers the interlinearizer.saveAnalysis command', async () => {
       const context = createTestActivationContext();

--- a/src/__tests__/test-helpers.ts
+++ b/src/__tests__/test-helpers.ts
@@ -1,8 +1,4 @@
-/**
- * @file Test helpers used to build type-safe mocks without type assertions. Provides a minimal
- *   ExecutionActivationContext that satisfies @papi/core types, a `useWebViewState` hook stub for
- *   component tests, and shared Book and analysis fixtures.
- */
+/** @file Shared test helpers for unit and component tests. */
 import type { SerializedVerseRef } from '@sillsdev/scripture';
 import type { ExecutionActivationContext } from '@papi/core';
 import type { Book, InterlinearProject, PhraseAnalysisLink, Token } from 'interlinearizer';

--- a/src/components/PhraseBox.tsx
+++ b/src/components/PhraseBox.tsx
@@ -163,9 +163,10 @@ export function PhraseBox({
     tokenDocOrder,
     simplifyPhrases,
   } = usePhraseStripContext();
-  // When simplifyPhrases is on, a phrase exposes its interactive controls (intra-phrase unlink
-  // icons, remove-token ✕) only while it is the focused phrase. Non-focused phrases keep their
-  // hover style but render no controls.
+  // When simplifyPhrases is on, a phrase exposes its interactive controls only while focused.
+  // Intra-phrase unlink icons are hidden via opacity/pointer-events (not unmounted) so the layout
+  // gap they occupy is preserved. The remove-token ✕ is omitted from onRemove instead (it only
+  // appears as a prop-driven overlay, so omitting it has no layout impact).
   const controlsSuppressed = simplifyPhrases && !isFocused;
   const { updatePhrase, deletePhrase } = usePhraseDispatch();
 
@@ -350,15 +351,23 @@ export function PhraseBox({
               <span key={token.ref} className="tw:phrase-token-row">
                 {i > 0 && (
                   <span className="tw:inline-flex tw:flex-col tw:items-center">
-                    {isRealPhrase && !controlsSuppressed && (
-                      <MemoizedTokenLinkIcon
-                        slotFocus={NO_SLOT_FOCUS}
-                        isPhraseRevealed={isHighlighted}
-                        nextPhraseLink={phraseLink}
-                        nextToken={token}
-                        prevPhraseLink={phraseLink}
-                        prevToken={tokens[i - 1]}
-                      />
+                    {isRealPhrase && (
+                      <span
+                        aria-hidden={controlsSuppressed || undefined}
+                        style={{
+                          opacity: controlsSuppressed ? 0 : 1,
+                          pointerEvents: controlsSuppressed ? 'none' : undefined,
+                        }}
+                      >
+                        <MemoizedTokenLinkIcon
+                          slotFocus={NO_SLOT_FOCUS}
+                          isPhraseRevealed={isHighlighted}
+                          nextPhraseLink={phraseLink}
+                          nextToken={token}
+                          prevPhraseLink={phraseLink}
+                          prevToken={tokens[i - 1]}
+                        />
+                      </span>
                     )}
                     {punctuationBetween?.[i - 1] && punctuationBetween[i - 1].length > 0 && (
                       <span className="tw:inline-flex tw:flex-row tw:items-center">

--- a/src/store/analysisSlice.ts
+++ b/src/store/analysisSlice.ts
@@ -92,6 +92,30 @@ export const defaultState: AnalysisState = {
 
 // #region Slice
 
+/**
+ * Derives the display surface text for a phrase by joining each token's surface text with a space.
+ *
+ * @param tokens - Ordered token snapshots forming the phrase, in document order.
+ * @returns The space-joined surface text string.
+ */
+function phraseSurfaceText(tokens: TokenSnapshot[]): string {
+  return tokens.map((t) => t.surfaceText).join(' ');
+}
+
+/**
+ * Removes the `PhraseAnalysis` record and its `PhraseAnalysisLink` matching `phraseId` from the
+ * Immer draft state in a single step, ensuring both collections stay in sync.
+ *
+ * @param state - Current slice state (Immer draft).
+ * @param phraseId - ID of the phrase to remove.
+ */
+function removePhraseById(state: AnalysisState, phraseId: string): void {
+  state.analysis.phraseAnalyses = state.analysis.phraseAnalyses.filter((pa) => pa.id !== phraseId);
+  state.analysis.phraseAnalysisLinks = state.analysis.phraseAnalysisLinks.filter(
+    (pl) => pl.analysisId !== phraseId,
+  );
+}
+
 const analysisSlice = createSlice({
   name: 'analysis',
   initialState: defaultState,
@@ -183,8 +207,7 @@ const analysisSlice = createSlice({
        */
       reducer(state, action: PayloadAction<CreatePhrasePayload>) {
         const { id, tokens } = action.payload;
-        const surfaceText = tokens.map((t) => t.surfaceText).join(' ');
-        const newAnalysis: PhraseAnalysis = { id, surfaceText };
+        const newAnalysis: PhraseAnalysis = { id, surfaceText: phraseSurfaceText(tokens) };
         const newLink: PhraseAnalysisLink = { analysisId: id, status: 'approved', tokens };
         state.analysis.phraseAnalyses.push(newAnalysis);
         state.analysis.phraseAnalysisLinks.push(newLink);
@@ -204,18 +227,13 @@ const analysisSlice = createSlice({
     updatePhrase(state, action: PayloadAction<UpdatePhrasePayload>) {
       const { phraseId, tokens } = action.payload;
       if (tokens.length === 0) {
-        state.analysis.phraseAnalyses = state.analysis.phraseAnalyses.filter(
-          (pa) => pa.id !== phraseId,
-        );
-        state.analysis.phraseAnalysisLinks = state.analysis.phraseAnalysisLinks.filter(
-          (pl) => pl.analysisId !== phraseId,
-        );
+        removePhraseById(state, phraseId);
         return;
       }
       const link = state.analysis.phraseAnalysisLinks.find((l) => l.analysisId === phraseId);
       if (link) link.tokens = tokens;
       const analysis = state.analysis.phraseAnalyses.find((pa) => pa.id === phraseId);
-      if (analysis) analysis.surfaceText = tokens.map((t) => t.surfaceText).join(' ');
+      if (analysis) analysis.surfaceText = phraseSurfaceText(tokens);
     },
     /**
      * Removes the `PhraseAnalysis` record and its `PhraseAnalysisLink` for the given phrase id.
@@ -225,12 +243,7 @@ const analysisSlice = createSlice({
      */
     deletePhrase(state, action: PayloadAction<DeletePhrasePayload>) {
       const { phraseId } = action.payload;
-      state.analysis.phraseAnalyses = state.analysis.phraseAnalyses.filter(
-        (pa) => pa.id !== phraseId,
-      );
-      state.analysis.phraseAnalysisLinks = state.analysis.phraseAnalysisLinks.filter(
-        (pl) => pl.analysisId !== phraseId,
-      );
+      removePhraseById(state, phraseId);
     },
     /**
      * Merges a neighboring phrase (or a free token) into the target phrase as a single atomic
@@ -253,15 +266,8 @@ const analysisSlice = createSlice({
       const link = state.analysis.phraseAnalysisLinks.find((l) => l.analysisId === targetPhraseId);
       if (link) link.tokens = tokens;
       const analysis = state.analysis.phraseAnalyses.find((pa) => pa.id === targetPhraseId);
-      if (analysis) analysis.surfaceText = tokens.map((t) => t.surfaceText).join(' ');
-      if (absorbedPhraseId !== undefined) {
-        state.analysis.phraseAnalyses = state.analysis.phraseAnalyses.filter(
-          (pa) => pa.id !== absorbedPhraseId,
-        );
-        state.analysis.phraseAnalysisLinks = state.analysis.phraseAnalysisLinks.filter(
-          (pl) => pl.analysisId !== absorbedPhraseId,
-        );
-      }
+      if (analysis) analysis.surfaceText = phraseSurfaceText(tokens);
+      if (absorbedPhraseId !== undefined) removePhraseById(state, absorbedPhraseId);
     },
     /**
      * Writes a gloss value into the `PhraseAnalysis` record for the given phrase id. No-ops when no


### PR DESCRIPTION
## Summary

- Intra-phrase unlink icons are now hidden via opacity (rather than removed) when `simplifyPhrases` is on, preserving layout stability
- Removed a stale documentation file
- Extracted three helpers:
  - `activateAndGetHandler<T>` in `main.test.ts`;
  - `removePhraseById` + `phraseSurfaceText` in `analysisSlice.ts`

Builds on #91.

Devin review: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/101

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/101)
<!-- Reviewable:end -->
