### PR TITLE
Address review findings: navigation edge cases, dropdown stacking, verse-0 dead code

### DIFF
--- a/src/__tests__/components/ContinuousView.test.tsx
+++ b/src/__tests__/components/ContinuousView.test.tsx
@@ -793,6 +793,31 @@ describe('ContinuousView arrow navigation', () => {
     expect(props.onFocusedTokenRefChange).toHaveBeenNthCalledWith(1, 'tok-1');
     expect(props.onFocusedTokenRefChange).toHaveBeenNthCalledWith(2, 'tok-2');
   });
+
+  it('steps from the externally-imposed focus, not the stale pending index, after an external change interrupts an in-flight internal nav', async () => {
+    // Sequence: an external nav (tok-3) starts its fade while tok-1 is still displayed; the user
+    // clicks Next during the fade (internal nav in flight — this parent never echoes it); then a
+    // second external change lands back on the still-displayed tok-1. Because that value equals the
+    // displayed ref, the focus-change effect early-returns without clearing the in-flight marker,
+    // so only the render-phase external-override detection resyncs the pending index. Without it,
+    // the next step would advance from the stale pending index (group 2 → tok-1) instead of the
+    // externally-imposed position (group 1 → tok-0).
+    const book = makeBook();
+    const props = requiredProps(book, { focusedTokenRef: 'tok-1' });
+    const { rerender } = render(<ContinuousView {...props} />, withAnalysisStore);
+
+    // External nav while idle: the fade starts; the displayed focus is still tok-1.
+    rerender(<ContinuousView {...props} focusedTokenRef="tok-3" />);
+    // Internal nav in flight: Next from the displayed group (tok-1) emits tok-2.
+    await userEvent.click(screen.getByRole('button', { name: 'Next token' }));
+    expect(props.onFocusedTokenRefChange).toHaveBeenNthCalledWith(1, 'tok-2');
+
+    // The parent imposes an external position (not the tok-2 echo) that matches the displayed ref.
+    rerender(<ContinuousView {...props} focusedTokenRef="tok-1" />);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Previous token' }));
+    expect(props.onFocusedTokenRefChange).toHaveBeenNthCalledWith(2, 'tok-0');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/components/InterlinearNavContext.test.tsx
+++ b/src/__tests__/components/InterlinearNavContext.test.tsx
@@ -5,7 +5,11 @@
 import type { SerializedVerseRef } from '@sillsdev/scripture';
 import { act, renderHook } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { InterlinearNavProvider, useInterlinearNav } from '../../components/InterlinearNavContext';
+import {
+  INTERNAL_NAV_TTL_MS,
+  InterlinearNavProvider,
+  useInterlinearNav,
+} from '../../components/InterlinearNavContext';
 import { RECENTER_FADE_MS } from '../../components/recenter-fade';
 
 /** Tuple shape returned by the PAPI scroll-group hook. */
@@ -264,6 +268,33 @@ describe('InterlinearNavContext', () => {
       });
       expect(result.current.consumeInternalNav(a)).toBe(true);
       expect(result.current.consumeInternalNav(b)).toBe(true);
+    });
+
+    it('expires a stranded internal mark after the TTL so a later external navigation fades', () => {
+      // When React batches two rapid internal clicks (verse A then B in one frame), the host
+      // echoes only the final value: B's marker is consumed but A's is stranded. Once the TTL has
+      // passed, a later external navigation to A must classify as external (consume returns
+      // false), not be misread as internal by the stale marker.
+      jest.useFakeTimers();
+      try {
+        const { result } = renderNav(
+          makeScrollGroupHook({ book: 'GEN', chapterNum: 1, verseNum: 1 }),
+        );
+        const a: SerializedVerseRef = { book: 'GEN', chapterNum: 1, verseNum: 5 };
+        const b: SerializedVerseRef = { book: 'GEN', chapterNum: 1, verseNum: 10 };
+
+        act(() => {
+          result.current.navigate(a, 'internal');
+          result.current.navigate(b, 'internal');
+        });
+        // The host coalesces the batched navigations and echoes only the final value.
+        expect(result.current.consumeInternalNav(b)).toBe(true);
+
+        jest.advanceTimersByTime(INTERNAL_NAV_TTL_MS + 1);
+        expect(result.current.consumeInternalNav(a)).toBe(false);
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     it('matches a verse-0 internal mark against the host-normalized verse-1 reference', () => {

--- a/src/__tests__/components/InterlinearNavContext.test.tsx
+++ b/src/__tests__/components/InterlinearNavContext.test.tsx
@@ -513,6 +513,36 @@ describe('InterlinearNavContext', () => {
       expect(result.current.fadePhase).toBe('in');
     });
 
+    it('re-engages the curtain when an expired stranded internal mark names the mid-reveal target', () => {
+      // A stranded internal marker (its echo never arrived) must stop exempting the verse once the
+      // TTL passes: a later external navigation to that verse landing mid-reveal still re-engages
+      // the curtain. Markers stamp at navigate time and RECENTER_FADE_MS (500ms) is far shorter
+      // than the TTL (3000ms), so the clock is advanced past the TTL *before* the reveal begins —
+      // advancing during the 'in' phase would fire the fade-in timer to 'idle' first.
+      const { result, rerender, setRef } = renderNavMutable({
+        book: 'GEN',
+        chapterNum: 1,
+        verseNum: 1,
+      });
+
+      // Strand a marker for the eventual target: an internal navigation whose echo never arrives.
+      act(() => result.current.navigate({ book: 'ZEP', chapterNum: 3, verseNum: 1 }, 'internal'));
+      // Let the marker expire while the clock is still idle.
+      act(() => jest.advanceTimersByTime(INTERNAL_NAV_TTL_MS + 1));
+
+      // Cross-book navigation, then settle: the curtain is mid-reveal ('in').
+      act(() => setRef({ book: 'ZEP', chapterNum: 1, verseNum: 1 }));
+      rerender();
+      act(() => result.current.reportSettled());
+      expect(result.current.fadePhase).toBe('in');
+
+      // An external navigation to the stranded verse lands mid-reveal. The expired marker must not
+      // exempt it: the curtain re-engages.
+      act(() => setRef({ book: 'ZEP', chapterNum: 3, verseNum: 1 }));
+      rerender();
+      expect(result.current.fadePhase).toBe('out');
+    });
+
     it('does not re-engage the curtain for a verse-0 echo during the fade-in', () => {
       // The host's chapter re-broadcast (verse 0 for the chapter already shown) is sticky — it
       // names the verse currently displayed, so it must not read as a fresh navigation mid-reveal.

--- a/src/__tests__/components/Interlinearizer.test.tsx
+++ b/src/__tests__/components/Interlinearizer.test.tsx
@@ -419,13 +419,6 @@ describe('Interlinearizer', () => {
     expect(capturedSegmentViewPropsList[1].isActive).toBeFalsy();
   });
 
-  it('renders all segments when navigating to a title reference (verse 0)', () => {
-    const titleRef: SerializedVerseRef = { book: 'GEN', chapterNum: 1, verseNum: 0 };
-    renderInterlinearizer({ book: GEN_1_MULTI_BOOK, scrRef: titleRef });
-
-    expect(screen.getAllByTestId('segment-view')).toHaveLength(2);
-  });
-
   it('calls setScrRef with the segment ref when a segment fires onSelect', () => {
     const mockNavigate = jest.fn();
     renderInterlinearizer({ book: GEN_1_MULTI_BOOK, navigate: mockNavigate });
@@ -836,45 +829,6 @@ describe('Interlinearizer', () => {
 
     expect(screen.queryByText('Chapter 1')).not.toBeInTheDocument();
     expect(screen.queryByText('Chapter 2')).not.toBeInTheDocument();
-  });
-
-  it('tags each inline chapter header with its chapter number for snap targeting', () => {
-    renderInterlinearizer({
-      book: GEN_TWO_CHAPTER_BOOK,
-      scrRef: { book: 'GEN', chapterNum: 1, verseNum: 1 },
-      continuousScroll: false,
-    });
-
-    expect(screen.getByText('Chapter 1')).toHaveAttribute('data-chapter-start', '1');
-    expect(screen.getByText('Chapter 2')).toHaveAttribute('data-chapter-start', '2');
-  });
-
-  it('highlights the first verse of a chapter when the reference names verse 0 (the heading)', () => {
-    renderInterlinearizer({
-      book: GEN_TWO_CHAPTER_BOOK,
-      scrRef: { book: 'GEN', chapterNum: 2, verseNum: 0 },
-      continuousScroll: false,
-    });
-
-    // Verse 0 names the chapter heading, which is not a verse; the active-verse marker still lands
-    // on the chapter's first segment so a verse stays highlighted.
-    const activeIds = new Set(
-      capturedSegmentViewPropsList.filter((p) => p.isActive).map((p) => p.segment.id),
-    );
-    expect([...activeIds]).toEqual(['GEN 2:1']);
-  });
-
-  it('scrolls the chapter heading to the top when the reference names verse 0', () => {
-    const scrollSpy = jest.spyOn(Element.prototype, 'scrollIntoView');
-    renderInterlinearizer({
-      book: GEN_TWO_CHAPTER_BOOK,
-      scrRef: { book: 'GEN', chapterNum: 2, verseNum: 0 },
-      continuousScroll: false,
-    });
-
-    // The snap targets the chapter-2 heading element rather than the active verse-1 segment.
-    const heading = screen.getByText('Chapter 2');
-    expect(scrollSpy.mock.contexts).toContain(heading);
   });
 
   it('renders the snap-to-active-verse button when segments are present', () => {

--- a/src/__tests__/hooks/useSegmentWindow.test.ts
+++ b/src/__tests__/hooks/useSegmentWindow.test.ts
@@ -670,52 +670,6 @@ describe('useSegmentWindow', () => {
     expect(scrollIntoView).toHaveBeenCalledWith({ behavior: 'auto', block: 'start' });
   });
 
-  it('snaps the chapter heading (not the active verse) when the reference names verse 0', () => {
-    const book = makeBook(60, 60);
-    const scrollIntoView = jest.spyOn(Element.prototype, 'scrollIntoView');
-    const { container, rerender } = renderSegmentWindow(book, {
-      book: 'GEN',
-      chapterNum: 1,
-      verseNum: 1,
-    });
-
-    // Mount both candidate targets: the active verse-1 segment and the chapter-2 heading. A verse-0
-    // reference should snap the heading, leaving the active verse highlighted below it.
-    const active = document.createElement('div');
-    active.setAttribute('aria-current', 'true');
-    container.appendChild(active);
-    const heading = document.createElement('span');
-    heading.setAttribute('data-chapter-start', '2');
-    container.appendChild(heading);
-
-    act(() => rerender({ b: book, ref: { book: 'GEN', chapterNum: 2, verseNum: 0 } }));
-    act(() => jest.advanceTimersByTime(RECENTER_FADE_MS));
-
-    expect(scrollIntoView.mock.contexts).toContain(heading);
-    expect(scrollIntoView.mock.contexts).not.toContain(active);
-  });
-
-  it('falls back to the active verse for a verse-0 reference when no heading is mounted', () => {
-    const book = makeBook(60, 60);
-    const scrollIntoView = jest.spyOn(Element.prototype, 'scrollIntoView');
-    const { container, rerender } = renderSegmentWindow(book, {
-      book: 'GEN',
-      chapterNum: 1,
-      verseNum: 1,
-    });
-
-    // No `[data-chapter-start]` element (headings suppressed by chapterLabelInVerse), so the snap
-    // falls back to the active verse.
-    const active = document.createElement('div');
-    active.setAttribute('aria-current', 'true');
-    container.appendChild(active);
-
-    act(() => rerender({ b: book, ref: { book: 'GEN', chapterNum: 2, verseNum: 0 } }));
-    act(() => jest.advanceTimersByTime(RECENTER_FADE_MS));
-
-    expect(scrollIntoView.mock.contexts).toContain(active);
-  });
-
   it('grows the snap spacer when scrollIntoView cannot reach the top', () => {
     const book = makeBook(60, 0);
     const scrollIntoView = jest.fn();

--- a/src/components/ContinuousView.tsx
+++ b/src/components/ContinuousView.tsx
@@ -259,6 +259,28 @@ export default function ContinuousView({
    * group instead of two.
    */
   const pendingPhraseIndexRef = useRef(0);
+
+  /**
+   * `focusedTokenRef` prop value from the previous render. Lets the sync block below distinguish a
+   * prop that merely hasn't echoed an in-flight internal nav yet (unchanged since last render) from
+   * one the parent changed to an external position (changed to something other than the in-flight
+   * ref).
+   */
+  const prevFocusedTokenRefPropRef = useRef(focusedTokenRef);
+  // If the prop changed to anything other than the in-flight internal ref, the parent imposed an
+  // external position instead of echoing the nav. Clear the in-flight marker so the pending index
+  // resyncs below; otherwise the next step() would advance from the stale pending index rather
+  // than the externally-imposed position. The focus-change effect can't cover this case: it
+  // early-returns without clearing the marker when the external value already matches the
+  // displayed ref.
+  if (
+    internalFocusedTokenRefRef.current !== undefined &&
+    focusedTokenRef !== prevFocusedTokenRefPropRef.current &&
+    focusedTokenRef !== internalFocusedTokenRefRef.current
+  ) {
+    internalFocusedTokenRefRef.current = undefined;
+  }
+  prevFocusedTokenRefPropRef.current = focusedTokenRef;
   // Keep in sync with the rendered value so external jumps reset the pending index. When an
   // internal nav is still in flight (the parent hasn't echoed back yet), do not overwrite: a rapid
   // second click needs to read the already-advanced pending index rather than the stale rendered

--- a/src/components/InterlinearNavContext.tsx
+++ b/src/components/InterlinearNavContext.tsx
@@ -89,6 +89,18 @@ export function verseKey(ref: SerializedVerseRef): string {
 }
 
 /**
+ * How long an unconsumed internal-navigation marker stays valid, in milliseconds. A marker is
+ * normally consumed by the host's echo of the navigated reference within a few milliseconds; one
+ * can only go unconsumed when React batches rapid internal clicks (verse A then verse B in one
+ * frame) and the host echoes just the final value, leaving A's marker stranded. Without an expiry,
+ * a much-later _external_ navigation to A would consume the stale marker and skip the recenter fade
+ * it should show. A few seconds is orders of magnitude beyond any echo round-trip, so a legitimate
+ * marker can never expire early, while a stranded one is gone long before the user could plausibly
+ * navigate back to that verse externally.
+ */
+export const INTERNAL_NAV_TTL_MS = 3000;
+
+/**
  * The single navigation surface for the Interlinearizer WebView. Owns the scripture reference, the
  * scroll-group linkage, the cross-book fade clock, and the internal/external classification of each
  * navigation that were previously read and written by the loader, `Interlinearizer`, and the
@@ -128,7 +140,10 @@ export interface InterlinearNav {
    * Consumes a pending internal-navigation marker for `ref`: returns `true` (and clears the marker)
    * when the most recent {@link navigate} to this verse was `internal`, else `false`. The segment
    * window calls this when an anchor change arrives to decide whether to fade. Consuming clears the
-   * marker so a later _external_ navigation to the same verse still fades.
+   * marker so a later _external_ navigation to the same verse still fades. Markers older than
+   * {@link INTERNAL_NAV_TTL_MS} are ignored (and discarded): a marker stranded by React batching
+   * rapid clicks — where the host echoes only the last of several internal navigations — must not
+   * misclassify a later external navigation to the un-echoed verse.
    *
    * @param ref - The reference whose pending classification to consume.
    * @returns `true` if the navigation to `ref` was internal (skip the fade), else `false`.
@@ -242,26 +257,37 @@ export function InterlinearNavProvider({
   liveScrRefRef.current = liveScrRef;
 
   /**
-   * Verse keys of internal navigations still awaiting their host round-trip. A `navigate(ref,
-   * 'internal')` adds `verseKey(ref)`; `consumeInternalNav` removes it on match. A set (not a
-   * single value) handles rapid successive internal clicks: if two verses are clicked before the
-   * host delivers the first `liveScrRef`, both keys stay pending so neither delivery is misread as
-   * external.
+   * Verse keys of internal navigations still awaiting their host round-trip, each mapped to its
+   * `Date.now()` stamp. A `navigate(ref, 'internal')` records `verseKey(ref)`; `consumeInternalNav`
+   * removes it on match. A keyed collection (not a single value) handles rapid successive internal
+   * clicks: if two verses are clicked before the host delivers the first `liveScrRef`, both keys
+   * stay pending so neither delivery is misread as external. The stamp puts a TTL
+   * ({@link INTERNAL_NAV_TTL_MS}) on each marker: when React batches such rapid clicks into one
+   * update, the host echoes only the final value, stranding the earlier marker — unexpired, it
+   * would misclassify a later external navigation to that verse as internal and suppress its
+   * recenter fade.
    */
-  const pendingInternalNavRef = useRef<Set<string>>(new Set());
+  const pendingInternalNavRef = useRef<Map<string, number>>(new Map());
 
   const navigate = useCallback(
     (newScrRef: SerializedVerseRef, origin: NavOrigin = 'external') => {
-      if (origin === 'internal') pendingInternalNavRef.current.add(verseKey(newScrRef));
+      if (origin === 'internal') pendingInternalNavRef.current.set(verseKey(newScrRef), Date.now());
       setScrRef(newScrRef);
     },
     [setScrRef],
   );
 
   const consumeInternalNav = useCallback((ref: SerializedVerseRef) => {
+    const pending = pendingInternalNavRef.current;
+    // Evict expired markers before matching, so a marker stranded by a batched rapid-click (its
+    // echo never arrived) cannot be consumed by a later external navigation to the same verse.
+    const cutoff = Date.now() - INTERNAL_NAV_TTL_MS;
+    pending.forEach((stampedAt, pendingKey) => {
+      if (stampedAt < cutoff) pending.delete(pendingKey);
+    });
     const key = verseKey(ref);
-    if (!pendingInternalNavRef.current.has(key)) return false;
-    pendingInternalNavRef.current.delete(key);
+    if (!pending.has(key)) return false;
+    pending.delete(key);
     return true;
   }, []);
 

--- a/src/components/InterlinearNavContext.tsx
+++ b/src/components/InterlinearNavContext.tsx
@@ -101,6 +101,19 @@ export function verseKey(ref: SerializedVerseRef): string {
 export const INTERNAL_NAV_TTL_MS = 3000;
 
 /**
+ * The single freshness definition for an internal-navigation marker, shared by both marker readers
+ * — `consumeInternalNav` and the render-phase mid-reveal guard — so the two can never drift on what
+ * counts as expired. The boundary is consistent with eviction: a marker is fresh iff its age is at
+ * most {@link INTERNAL_NAV_TTL_MS}.
+ *
+ * @param stampedAt - The marker's `Date.now()` stamp, or `undefined` when no marker exists.
+ * @returns `true` when a marker exists and is within the TTL.
+ */
+function isInternalNavMarkerFresh(stampedAt: number | undefined): boolean {
+  return stampedAt !== undefined && Date.now() - stampedAt <= INTERNAL_NAV_TTL_MS;
+}
+
+/**
  * The single navigation surface for the Interlinearizer WebView. Owns the scripture reference, the
  * scroll-group linkage, the cross-book fade clock, and the internal/external classification of each
  * navigation that were previously read and written by the loader, `Interlinearizer`, and the
@@ -265,7 +278,8 @@ export function InterlinearNavProvider({
    * ({@link INTERNAL_NAV_TTL_MS}) on each marker: when React batches such rapid clicks into one
    * update, the host echoes only the final value, stranding the earlier marker — unexpired, it
    * would misclassify a later external navigation to that verse as internal and suppress its
-   * recenter fade.
+   * recenter fade. BOTH readers honor the TTL: `consumeInternalNav` (which also evicts expired
+   * markers) and the render-phase mid-reveal guard (a pure read — no eviction during render).
    */
   const pendingInternalNavRef = useRef<Map<string, number>>(new Map());
 
@@ -281,9 +295,10 @@ export function InterlinearNavProvider({
     const pending = pendingInternalNavRef.current;
     // Evict expired markers before matching, so a marker stranded by a batched rapid-click (its
     // echo never arrived) cannot be consumed by a later external navigation to the same verse.
-    const cutoff = Date.now() - INTERNAL_NAV_TTL_MS;
+    // Eviction also bounds the map's size; freshness is the shared `isInternalNavMarkerFresh`
+    // definition so this reader and the mid-reveal guard cannot drift.
     pending.forEach((stampedAt, pendingKey) => {
-      if (stampedAt < cutoff) pending.delete(pendingKey);
+      if (!isInternalNavMarkerFresh(stampedAt)) pending.delete(pendingKey);
     });
     const key = verseKey(ref);
     if (!pending.has(key)) return false;
@@ -324,7 +339,7 @@ export function InterlinearNavProvider({
   } else if (
     fadePhase === 'in' &&
     verseKey(liveScrRef) !== verseKey(prevLiveScrRef) &&
-    !pendingInternalNavRef.current.has(verseKey(liveScrRef))
+    !isInternalNavMarkerFresh(pendingInternalNavRef.current.get(verseKey(liveScrRef)))
   ) {
     // A follow-up external navigation landing while the cross-book reveal is still animating. The
     // host resolves one picker selection as two navigations — the book change first, the precise
@@ -334,7 +349,10 @@ export function InterlinearNavProvider({
     // transition carries the opacity smoothly down from wherever the rise had reached), let the
     // views re-anchor on the new verse behind it, and lift once on their settle. Internal echoes
     // (a click made during the reveal) are exempt — the curtain must not drop over a navigation
-    // whose target is already on screen.
+    // whose target is already on screen — but the exemption honors the marker TTL, so an expired
+    // stranded marker (a batched rapid-click whose echo never arrived) cannot suppress the
+    // re-engage. The read is pure (no eviction): this runs during render, so the map must not be
+    // mutated here; `consumeInternalNav` handles eviction.
     /* v8 ignore next -- defensive: reportSettled always arms the fade-in timer alongside 'in' */
     if (fadeInTimeoutRef.current !== undefined) clearTimeout(fadeInTimeoutRef.current);
     fadeInTimeoutRef.current = undefined;

--- a/src/components/InterlinearNavContext.tsx
+++ b/src/components/InterlinearNavContext.tsx
@@ -89,14 +89,11 @@ export function verseKey(ref: SerializedVerseRef): string {
 }
 
 /**
- * How long an unconsumed internal-navigation marker stays valid, in milliseconds. A marker is
- * normally consumed by the host's echo of the navigated reference within a few milliseconds; one
- * can only go unconsumed when React batches rapid internal clicks (verse A then verse B in one
- * frame) and the host echoes just the final value, leaving A's marker stranded. Without an expiry,
- * a much-later _external_ navigation to A would consume the stale marker and skip the recenter fade
- * it should show. A few seconds is orders of magnitude beyond any echo round-trip, so a legitimate
- * marker can never expire early, while a stranded one is gone long before the user could plausibly
- * navigate back to that verse externally.
+ * How long an unconsumed internal-navigation marker stays valid, in milliseconds. The host's echo
+ * normally consumes a marker within milliseconds, but when React batches rapid clicks (verse A then
+ * B in one frame) the host echoes only the final value, stranding A's marker. Without expiry, a
+ * much-later external navigation to A would consume the stale marker and skip its recenter fade. 3s
+ * is far beyond any echo round-trip yet well before the user could plausibly navigate back.
  */
 export const INTERNAL_NAV_TTL_MS = 3000;
 
@@ -271,15 +268,12 @@ export function InterlinearNavProvider({
 
   /**
    * Verse keys of internal navigations still awaiting their host round-trip, each mapped to its
-   * `Date.now()` stamp. A `navigate(ref, 'internal')` records `verseKey(ref)`; `consumeInternalNav`
-   * removes it on match. A keyed collection (not a single value) handles rapid successive internal
-   * clicks: if two verses are clicked before the host delivers the first `liveScrRef`, both keys
-   * stay pending so neither delivery is misread as external. The stamp puts a TTL
-   * ({@link INTERNAL_NAV_TTL_MS}) on each marker: when React batches such rapid clicks into one
-   * update, the host echoes only the final value, stranding the earlier marker — unexpired, it
-   * would misclassify a later external navigation to that verse as internal and suppress its
-   * recenter fade. BOTH readers honor the TTL: `consumeInternalNav` (which also evicts expired
-   * markers) and the render-phase mid-reveal guard (a pure read — no eviction during render).
+   * `Date.now()` stamp. `navigate(ref, 'internal')` records `verseKey(ref)`; `consumeInternalNav`
+   * removes it on match. Keyed (not a single value) so that rapid successive clicks both stay
+   * pending and neither host delivery is misread as external. The stamp gives each marker a TTL
+   * ({@link INTERNAL_NAV_TTL_MS} — see its doc for why stranded markers must expire), honored by
+   * BOTH readers: `consumeInternalNav` (which also evicts expired markers) and the render-phase
+   * mid-reveal guard (a pure read — no eviction during render).
    */
   const pendingInternalNavRef = useRef<Map<string, number>>(new Map());
 
@@ -341,18 +335,14 @@ export function InterlinearNavProvider({
     verseKey(liveScrRef) !== verseKey(prevLiveScrRef) &&
     !isInternalNavMarkerFresh(pendingInternalNavRef.current.get(verseKey(liveScrRef)))
   ) {
-    // A follow-up external navigation landing while the cross-book reveal is still animating. The
-    // host resolves one picker selection as two navigations — the book change first, the precise
-    // target a beat later — so the second routinely arrives mid-fade-in. Left alone it would fade
-    // the freshly revealed content a second time (curtain up, content out, content in: the "double
-    // fade"). Instead, fold it into the same curtain cycle: re-engage the curtain (the CSS
-    // transition carries the opacity smoothly down from wherever the rise had reached), let the
-    // views re-anchor on the new verse behind it, and lift once on their settle. Internal echoes
-    // (a click made during the reveal) are exempt — the curtain must not drop over a navigation
-    // whose target is already on screen — but the exemption honors the marker TTL, so an expired
-    // stranded marker (a batched rapid-click whose echo never arrived) cannot suppress the
-    // re-engage. The read is pure (no eviction): this runs during render, so the map must not be
-    // mutated here; `consumeInternalNav` handles eviction.
+    // A follow-up external navigation landing mid-fade-in: the host resolves one picker selection
+    // as two navigations (book change, then precise target), so the second routinely arrives while
+    // the reveal is still animating and would fade the fresh content a second time. Instead,
+    // re-engage the curtain (the CSS transition carries opacity smoothly down from wherever the
+    // rise reached) and lift once when the views settle on the new verse. Internal echoes (a click
+    // made during the reveal) are exempt — their target is already on screen — but the exemption
+    // honors the marker TTL, so a stranded marker cannot suppress the re-engage. Pure read, no
+    // eviction: this runs during render; `consumeInternalNav` handles eviction.
     /* v8 ignore next -- defensive: reportSettled always arms the fade-in timer alongside 'in' */
     if (fadeInTimeoutRef.current !== undefined) clearTimeout(fadeInTimeoutRef.current);
     fadeInTimeoutRef.current = undefined;

--- a/src/components/Interlinearizer.tsx
+++ b/src/components/Interlinearizer.tsx
@@ -31,7 +31,12 @@ type InterlinearizerProps = Readonly<{
   book: Book;
   /** When true, the horizontal token strip is shown above the segment list. */
   continuousScroll: boolean;
-  /** Current scripture reference used to highlight the active verse. */
+  /**
+   * Current scripture reference used to highlight the active verse. Must carry a normalized verse
+   * number (>= 1): production refs flow through `normalizeScrRef` in `InterlinearNavContext`,
+   * which maps a verse-0 (chapter heading) selection to verse 1 before it reaches this component.
+   * A raw verse-0 ref would match no segment, leaving focus unseeded and nothing highlighted.
+   */
   scrRef: SerializedVerseRef;
   /**
    * BCP 47 tag for reading and writing gloss values. Defaults to `analysisLanguages[0]` of the
@@ -209,7 +214,9 @@ function InterlinearizerInner({
     updatePhrase(phraseMode.phraseId, phraseMode.originalTokens);
     setPhraseMode({ kind: 'view' });
     // phraseMode is intentionally omitted: adding it would re-fire on every edit
-    // keystroke; isRevert changing to true guarantees phraseMode holds the revert values.
+    // keystroke; isRevert changing to true guarantees phraseMode holds the revert values — a
+    // guarantee that holds only while isRevert stays derived directly from phraseMode above, so
+    // don't move or memoize that derivation independently of this effect.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isRevert, updatePhrase, setPhraseMode]);
 
@@ -228,7 +235,10 @@ function InterlinearizerInner({
     /* v8 ignore next -- activeSeg is always defined when the book includes the active verse */
     setFocusedTokenRef(firstWordTokenRefOf(activeSeg));
     // findActiveSegment is intentionally excluded: the verse-coordinate deps already capture the
-    // change we care about, and it changes identity on every scrRef update.
+    // change we care about, and it changes identity on every scrRef update. focusedTokenRef and
+    // tokenSegmentMap are excluded too — they are read only as guards; as deps they would re-run
+    // this effect on every focus move and clobber the deliberately-focused token with the verse's
+    // first word.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scrRef.book, scrRef.chapterNum, scrRef.verseNum]);
 
@@ -360,7 +370,8 @@ function InterlinearizerInner({
  * @param props - Component props
  * @param props.book - Book data used by the continuous view and segment window
  * @param props.continuousScroll - Whether the continuous scroll view is shown
- * @param props.scrRef - Current scripture reference
+ * @param props.scrRef - Current scripture reference; must be normalized (verse >= 1, see
+ *   {@link InterlinearizerProps}).
  * @param props.initialAnalysis - Seed analysis data for the store; not reactive after mount
  * @param props.analysisLanguage - BCP 47 tag for gloss read/write
  * @param props.onSaveAnalysis - Called after each gloss write with the updated `TextAnalysis`

--- a/src/components/Interlinearizer.tsx
+++ b/src/components/Interlinearizer.tsx
@@ -33,9 +33,9 @@ type InterlinearizerProps = Readonly<{
   continuousScroll: boolean;
   /**
    * Current scripture reference used to highlight the active verse. Must carry a normalized verse
-   * number (>= 1): production refs flow through `normalizeScrRef` in `InterlinearNavContext`,
-   * which maps a verse-0 (chapter heading) selection to verse 1 before it reaches this component.
-   * A raw verse-0 ref would match no segment, leaving focus unseeded and nothing highlighted.
+   * number (>= 1): production refs flow through `normalizeScrRef` in `InterlinearNavContext`, which
+   * maps a verse-0 (chapter heading) selection to verse 1 before it reaches this component. A raw
+   * verse-0 ref would match no segment, leaving focus unseeded and nothing highlighted.
    */
   scrRef: SerializedVerseRef;
   /**

--- a/src/components/SegmentListView.tsx
+++ b/src/components/SegmentListView.tsx
@@ -220,10 +220,7 @@ export default function SegmentListView({
             {windowSegments.map((seg) => (
               <Fragment key={seg.id}>
                 {!chapterLabelInVerse && chapterStartIds.has(seg.id) && (
-                  <span
-                    data-chapter-start={seg.startRef.chapter}
-                    className="tw:block tw:border-b tw:border-border tw:pb-1 tw:text-sm tw:font-semibold tw:text-foreground"
-                  >
+                  <span className="tw:block tw:border-b tw:border-border tw:pb-1 tw:text-sm tw:font-semibold tw:text-foreground">
                     {`Chapter ${seg.startRef.chapter}`}
                   </span>
                 )}
@@ -235,8 +232,7 @@ export default function SegmentListView({
                   isActive={
                     seg.startRef.book === displayScrRef.book &&
                     seg.startRef.chapter === displayScrRef.chapterNum &&
-                    (seg.startRef.verse === displayScrRef.verseNum ||
-                      (displayScrRef.verseNum === 0 && chapterStartIds.has(seg.id)))
+                    seg.startRef.verse === displayScrRef.verseNum
                   }
                   onHoverPhrase={setHoveredPhraseId}
                   onSelect={onSelect}

--- a/src/components/controls/ViewOptionsDropdown.tsx
+++ b/src/components/controls/ViewOptionsDropdown.tsx
@@ -153,12 +153,11 @@ export default function ViewOptionsDropdown({
         createPortal(
           /* Clicking outside the panel closes it. */
           <>
-            {/* The backdrop is an invisible click-catcher, so its z-index only affects hit
-                testing. It must stay BELOW the toolbar's stacking context (tw:z-10, created by the
-                sticky TabToolbarContainer) so the gear button itself receives clicks while the
-                dropdown is open and its onClick toggle — not the backdrop — closes it. Raising the
-                button instead would not work: the toolbar's stacking context caps every descendant
-                at level 10 against this portaled sibling. Keep panel (z-30) > backdrop. */}
+            {/* The invisible backdrop must stay BELOW the toolbar's stacking context (tw:z-10,
+                from the sticky TabToolbarContainer) so the gear button's onClick — not the
+                backdrop — closes the dropdown. Raising the button instead wouldn't work: the
+                toolbar caps its descendants at z-10 against this portaled sibling.
+                Keep panel (z-30) > backdrop. */}
             <div
               aria-hidden="true"
               className="tw:fixed tw:inset-0 tw:z-5"

--- a/src/components/controls/ViewOptionsDropdown.tsx
+++ b/src/components/controls/ViewOptionsDropdown.tsx
@@ -153,9 +153,15 @@ export default function ViewOptionsDropdown({
         createPortal(
           /* Clicking outside the panel closes it. */
           <>
+            {/* The backdrop is an invisible click-catcher, so its z-index only affects hit
+                testing. It must stay BELOW the toolbar's stacking context (tw:z-10, created by the
+                sticky TabToolbarContainer) so the gear button itself receives clicks while the
+                dropdown is open and its onClick toggle — not the backdrop — closes it. Raising the
+                button instead would not work: the toolbar's stacking context caps every descendant
+                at level 10 against this portaled sibling. Keep panel (z-30) > backdrop. */}
             <div
               aria-hidden="true"
-              className="tw:fixed tw:inset-0 tw:z-20"
+              className="tw:fixed tw:inset-0 tw:z-5"
               onClick={close}
               onKeyDown={undefined}
               role="presentation"

--- a/src/hooks/useSegmentWindow.ts
+++ b/src/hooks/useSegmentWindow.ts
@@ -425,12 +425,8 @@ export default function useSegmentWindow({
   );
 
   /**
-   * Snaps the recenter target to the top of the scroll container. Normally that is the active verse
-   * (the `aria-current` element). When the reference names verse 0 of a chapter — the chapter
-   * heading rather than any verse — the target is instead that chapter's inline heading (the
-   * `[data-chapter-start]` element), so the heading sits at the top while the active-verse
-   * highlight stays on verse 1 below it. Falls back to the active verse when no heading is mounted
-   * (e.g. the `chapterLabelInVerse` setting suppresses headings).
+   * Snaps the recenter target — the active verse (the `aria-current` element) — to the top of the
+   * scroll container.
    *
    * When the content below the target is too short for `scrollIntoView` to reach the top (common in
    * baseline-text mode where segments are compact, and especially after the continuous-scroll strip
@@ -441,12 +437,7 @@ export default function useSegmentWindow({
    */
   const snapActiveToTop = useCallback(() => {
     const container = scrollContainerRef.current;
-    const { verseNum, chapterNum } = scrRefRef.current;
-    const target =
-      verseNum === 0
-        ? (container?.querySelector(`[data-chapter-start="${chapterNum}"]`) ??
-          container?.querySelector('[aria-current="true"]'))
-        : container?.querySelector('[aria-current="true"]');
+    const target = container?.querySelector('[aria-current="true"]');
     /* v8 ignore next -- the recentered target is always mounted, so its element exists */
     if (!target || !container) return;
     const spacer = container.querySelector<HTMLElement>('[data-snap-spacer]');
@@ -458,7 +449,7 @@ export default function useSegmentWindow({
       spacer.style.height = `${Math.ceil(remainingOffset)}px`;
       target.scrollIntoView({ behavior: 'auto', block: 'start' });
     }
-  }, [scrollContainerRef, scrRefRef]);
+  }, [scrollContainerRef]);
 
   // Reconcile the container scroll position to the freshly-mounted range before the browser paints,
   // so neither an extend nor a recenter ever shows a jump. An extend mutated the window around a


### PR DESCRIPTION
Devin: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/103

Follow-ups to the segment-view rework, addressing code-review findings. Two navigation edge-case bugs, one real-browser click-handling fix, removal of an unreachable code path, and documentation hardening around fragile patterns the review called out.

## Navigation fixes

**Continuous strip: external navigation interrupting an in-flight internal step.** The strip tracks its pending phrase index in a ref so two rapid arrow clicks advance two groups before React re-renders. But when the parent imposed a new external `focusedTokenRef` while an internal step was still awaiting its echo, the in-flight marker suppressed the render-phase resync and the next step advanced from the stale index. The trigger is narrow but real: the focus-change effect early-returns when the new prop equals the currently displayed ref, so an external navigation landing on the displayed verse left the marker stuck indefinitely. The render-phase sync now detects an external override (the prop changed to something other than the in-flight internal ref), clears the marker, and resyncs the pending index. Covered by a regression test alongside the existing rapid-double-click test.

**Internal-navigation markers now expire.** When React batches rapid internal clicks into one update, the host echoes only the final reference, stranding the earlier verse's marker forever; a later external navigation to that verse would then be misclassified as internal and skip its recenter fade. Markers are now stamped (`Map<verseKey, timestamp>`) and expire after `INTERNAL_NAV_TTL_MS` (3 s — legitimate echoes round-trip in milliseconds, so nothing real can expire early). Both readers honor the TTL through a single shared freshness helper so they cannot drift: `consumeInternalNav` (which also evicts expired entries to bound the map) and the render-phase mid-reveal curtain guard (a pure read — no map mutation during render). Tests cover both the stranded-marker expiry and the mid-reveal re-engage with an expired marker naming the target verse.

## View-options dropdown: gear toggle works in real browsers

The portaled click-catcher backdrop sat at `z-20`, while the toolbar (`sticky` + `z-10`) caps all its descendants at level 10 — so in a real browser the gear button could never receive a click while the dropdown was open, and the tested toggle-closed path only passed because jsdom ignores z-index for hit-testing. Raising the button cannot work (the toolbar's stacking context caps it), so the backdrop drops to `z-5` instead: panel above toolbar above backdrop above page content. The backdrop is invisible, so this changes hit-testing only. One deliberate behavior change: while the dropdown is open, clicks on other toolbar controls now reach those controls directly instead of merely dismissing the dropdown.

## Unreachable verse-0 handling removed

`normalizeScrRef` maps a verse-0 (chapter heading) selection to verse 1 before the reference ever reaches the display layer, so the chapter-heading active/snap branches in `SegmentListView` and `useSegmentWindow.snapActiveToTop` could never run in production — their tests only passed by injecting `verseNum: 0` directly as a prop, bypassing the nav context. Those branches, the now-unconsumed `data-chapter-start` attribute, and their prop-injection tests are removed. Since the "scrRef is always normalized" assumption is now load-bearing, it is stated explicitly on `Interlinearizer`'s `scrRef` prop.

## Documentation hardening

The review flagged two effect dependency arrays as easy to break without understanding the design. Their comments now spell out the consequence: adding `focusedTokenRef`/`tokenSegmentMap` to the external-reseed effect would clobber the deliberately focused token on every focus move (they are guard-reads, not triggers), and the revert effect's correctness depends on `isRevert` staying derived directly from `phraseMode`.

## Testing

Full Jest suite green (893 tests, 34 suites), ESLint/stylelint/typecheck clean.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/103)
<!-- Reviewable:end -->
