### PR TITLE
Tiny tweaks

### DIFF
--- a/src/components/MorphemeEditor.tsx
+++ b/src/components/MorphemeEditor.tsx
@@ -59,8 +59,11 @@ export function MorphemeBreakdownPopover({
   }, []);
 
   // Whether the draft matches the pre-filled value. Shared by the Done/Enter and outside-click
-  // commit paths so the two can never disagree about what counts as an edit.
-  const isUnedited = draft.trim() === initialValue.trim();
+  // commit paths so the two can never disagree about what counts as an edit. Internal whitespace is
+  // collapsed because the save path splits on /\s+/, so differing spacing yields identical forms —
+  // comparing normalized text avoids a no-op persistence round-trip.
+  const normalize = (s: string) => s.trim().replace(/\s+/g, ' ');
+  const isUnedited = normalize(draft) === normalize(initialValue);
 
   /**
    * Commits the current draft and closes the popover. Skips the save when the token already has a

--- a/src/components/MorphemeEditor.tsx
+++ b/src/components/MorphemeEditor.tsx
@@ -58,11 +58,18 @@ export function MorphemeBreakdownPopover({
     inputRef.current?.select();
   }, []);
 
-  // Whether the draft matches the pre-filled value. Shared by the Done/Enter and outside-click
-  // commit paths so the two can never disagree about what counts as an edit. Internal whitespace is
-  // collapsed because the save path splits on /\s+/, so differing spacing yields identical forms —
-  // comparing normalized text avoids a no-op persistence round-trip.
+  /**
+   * Collapses leading/trailing and repeated internal whitespace to a single space.
+   *
+   * @param s - The string to normalize.
+   * @returns The string with surrounding whitespace trimmed and internal runs collapsed.
+   */
   const normalize = (s: string) => s.trim().replace(/\s+/g, ' ');
+
+  // Whether the draft matches the pre-filled value. Shared by the Done/Enter and outside-click
+  // commit paths so the two can never disagree about what counts as an edit. Whitespace is
+  // normalized because the save path splits on /\s+/, so differing spacing yields identical forms —
+  // comparing normalized text avoids a no-op persistence round-trip.
   const isUnedited = normalize(draft) === normalize(initialValue);
 
   /**

--- a/src/components/TokenChip.tsx
+++ b/src/components/TokenChip.tsx
@@ -161,6 +161,11 @@ export function TokenChip({
           // otherwise paint later segment rows over it. The popover is modal so interactions
           // outside the panel are blocked while it is open. The popover component is mounted only
           // while open so its draft state re-initializes from the current forms on every open.
+          //
+          // `onOpenChange` is intentionally omitted: this consumer owns every dismissal path
+          // (onEscapeKeyDown, onInteractOutside, explicit button clicks), so Radix's internal close
+          // requests aren't needed. Don't wire onOpenChange without also removing those, or closes
+          // would double-fire.
           <Popover modal open={popoverOpen}>
             <PopoverAnchor asChild>
               <div className="tw:relative tw:flex tw:flex-col tw:items-center tw:w-full">


### PR DESCRIPTION
Suggested tweaks on #104

Devin: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/109

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/109)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved whitespace handling when detecting unsaved changes—only meaningful content differences now trigger edit indicators. Spacing-only modifications are no longer marked as edits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->