### PR TITLE
Morpheme analysis UI: suggestions for #104

### DIFF
--- a/__mocks__/platform-bible-react.tsx
+++ b/__mocks__/platform-bible-react.tsx
@@ -361,6 +361,8 @@ export function PopoverAnchor({
  * - An Escape keydown anywhere inside the content invokes `onEscapeKeyDown`.
  * - A sentinel `data-testid="popover-outside"` button invokes `onInteractOutside` on click,
  *   simulating a pointer interaction outside the popover.
+ * - A sentinel `data-testid="popover-close"` button invokes `onCloseAutoFocus` on click,
+ *   simulating Radix's focus-restoration event fired as the popover closes.
  *
  * @param props - Component props.
  * @param props.children - Panel content.
@@ -371,6 +373,8 @@ export function PopoverAnchor({
  *   in `detail.originalEvent` when the sentinel outside button is clicked, matching the shape of
  *   Radix's `PointerDownOutsideEvent`.
  * @param props.onOpenAutoFocus - Called once on mount with a plain `Event`.
+ * @param props.onCloseAutoFocus - Called with a plain `Event` when the sentinel close button is
+ *   clicked, mirroring Radix's close-time focus-restoration event.
  * @param props.onClick - Click handler forwarded to the div.
  * @param props.onMouseDown - Mouse-down handler forwarded to the div.
  * @returns A `<div data-testid="popover-content">` with the panel content and sentinel controls.
@@ -381,6 +385,7 @@ export function PopoverContent({
   onEscapeKeyDown,
   onInteractOutside,
   onOpenAutoFocus,
+  onCloseAutoFocus,
   onClick,
   onMouseDown,
 }: Readonly<{
@@ -391,6 +396,7 @@ export function PopoverContent({
   onEscapeKeyDown?: (event: KeyboardEvent) => void;
   onInteractOutside?: (event: CustomEvent) => void;
   onOpenAutoFocus?: (event: Event) => void;
+  onCloseAutoFocus?: (event: Event) => void;
   onClick?: MouseEventHandler<HTMLDivElement>;
   onMouseDown?: MouseEventHandler<HTMLDivElement>;
 }>): ReactElement {
@@ -424,6 +430,15 @@ export function PopoverContent({
           }
         >
           outside
+        </button>
+      )}
+      {onCloseAutoFocus && (
+        <button
+          data-testid="popover-close"
+          type="button"
+          onClick={() => onCloseAutoFocus(new Event('closeAutoFocus'))}
+        >
+          close
         </button>
       )}
     </div>

--- a/contributions/localizedStrings.json
+++ b/contributions/localizedStrings.json
@@ -27,6 +27,13 @@
       "%interlinearizer_viewOption_showMorphology%": "Show morphology",
       "%interlinearizer_projectSettings_showMorphology%": "Show Morphology",
       "%interlinearizer_projectSettings_showMorphologyDescription%": "Display morpheme breakdown and per-morpheme glosses beneath each word token",
+      "%interlinearizer_morphemeEditor_splitLabel%": "Split into morphemes",
+      "%interlinearizer_morphemeEditor_delete%": "Delete",
+      "%interlinearizer_morphemeEditor_cancel%": "Cancel",
+      "%interlinearizer_morphemeEditor_done%": "Done",
+      "%interlinearizer_morphemeGloss_label%": "Gloss for morpheme {form}",
+      "%interlinearizer_tokenChip_editMorphemes%": "Edit morpheme breakdown for {token}",
+      "%interlinearizer_tokenChip_defineMorphemes%": "Define morpheme breakdown for {token}",
       "%interlinearizer_linkButton_crossSegmentDisabledTooltip%": "Cross-segment phrases are not supported. This link button is outside the current segment.",
 
       "%interlinearizer_modal_create_title%": "Create Interlinear Project",

--- a/src/__tests__/components/MorphemeEditor.test.tsx
+++ b/src/__tests__/components/MorphemeEditor.test.tsx
@@ -254,6 +254,43 @@ describe('MorphemeBreakdownPopover', () => {
     const content = screen.getByTestId('popover-content');
     expect(content).toContainElement(screen.getByText('Split into morphemes'));
   });
+
+  it('focuses the first morpheme gloss field of the chip when the popover closes', async () => {
+    // The chip label holds the morpheme gloss inputs before the token gloss input; on close, focus
+    // should land on the first morpheme gloss, scoped to this token's label via glossInputId.
+    render(
+      <label>
+        <input aria-label="morpheme gloss" data-morpheme-gloss="true" />
+        <input aria-label="token gloss" id="gloss-1" />
+        <MorphemeBreakdownPopover
+          glossInputId="gloss-1"
+          initialValue="word"
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          surfaceText="word"
+        />
+      </label>,
+    );
+    await userEvent.click(screen.getByTestId('popover-close'));
+    expect(screen.getByRole('textbox', { name: 'morpheme gloss' })).toHaveFocus();
+  });
+
+  it('falls back to the token gloss input on close when the chip has no morpheme gloss field', async () => {
+    render(
+      <label>
+        <input aria-label="token gloss" id="gloss-1" />
+        <MorphemeBreakdownPopover
+          glossInputId="gloss-1"
+          initialValue="word"
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          surfaceText="word"
+        />
+      </label>,
+    );
+    await userEvent.click(screen.getByTestId('popover-close'));
+    expect(screen.getByRole('textbox', { name: 'token gloss' })).toHaveFocus();
+  });
 });
 
 describe('MorphemeGlossInput', () => {

--- a/src/__tests__/components/MorphemeEditor.test.tsx
+++ b/src/__tests__/components/MorphemeEditor.test.tsx
@@ -2,37 +2,64 @@
 /// <reference types="jest" />
 /// <reference types="@testing-library/jest-dom" />
 
+import { useLocalizedStrings } from '@papi/frontend/react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ComponentProps } from 'react';
 import * as AnalysisStore from '../../components/AnalysisStore';
 import { MorphemeBreakdownPopover, MorphemeGlossInput } from '../../components/MorphemeEditor';
 
 jest.mock('../../components/AnalysisStore');
 
+const LOCALIZED = {
+  '%interlinearizer_morphemeEditor_splitLabel%': 'Split into morphemes',
+  '%interlinearizer_morphemeEditor_delete%': 'Delete',
+  '%interlinearizer_morphemeEditor_cancel%': 'Cancel',
+  '%interlinearizer_morphemeEditor_done%': 'Done',
+  '%interlinearizer_morphemeGloss_label%': 'Gloss for morpheme {form}',
+};
+
+beforeEach(() => {
+  jest.mocked(useLocalizedStrings).mockReturnValue([LOCALIZED, false]);
+});
+
+/**
+ * Renders {@link MorphemeBreakdownPopover} with the two structural props (`surfaceText`,
+ * `glossInputId`) defaulted so each test only supplies what it asserts on.
+ *
+ * @param props - Overrides merged over the defaults; callers pass their own `onSave`/`onClose`
+ *   spies.
+ * @returns The render result.
+ */
+function renderPopover(props: Partial<ComponentProps<typeof MorphemeBreakdownPopover>> = {}) {
+  return render(
+    <MorphemeBreakdownPopover
+      glossInputId="gloss-1"
+      initialValue="test"
+      onClose={jest.fn()}
+      onSave={jest.fn()}
+      surfaceText="word"
+      {...props}
+    />,
+  );
+}
+
 describe('MorphemeBreakdownPopover', () => {
   it('renders with the initial value pre-filled', () => {
-    render(
-      <MorphemeBreakdownPopover
-        initialValue="un- believe -able"
-        onSave={jest.fn()}
-        onClose={jest.fn()}
-      />,
-    );
+    renderPopover({ initialValue: 'un- believe -able' });
     const input = screen.getByRole('textbox');
     expect(input).toHaveValue('un- believe -able');
   });
 
   it('auto-focuses and selects the input on mount', () => {
-    render(<MorphemeBreakdownPopover initialValue="word" onSave={jest.fn()} onClose={jest.fn()} />);
+    renderPopover({ initialValue: 'word' });
     expect(screen.getByRole('textbox')).toHaveFocus();
   });
 
   it('calls onSave and onClose when Done button is clicked', async () => {
     const onSave = jest.fn();
     const onClose = jest.fn();
-    render(
-      <MorphemeBreakdownPopover initialValue="un- believe" onSave={onSave} onClose={onClose} />,
-    );
+    renderPopover({ initialValue: 'un- believe', onSave, onClose, surfaceText: 'unbelieve' });
     await userEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(onSave).toHaveBeenCalledWith('un- believe');
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -40,7 +67,7 @@ describe('MorphemeBreakdownPopover', () => {
 
   it('calls onSave with the edited value', async () => {
     const onSave = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="word" onSave={onSave} onClose={jest.fn()} />);
+    renderPopover({ initialValue: 'word', onSave, surfaceText: 'word' });
     await userEvent.clear(screen.getByRole('textbox'));
     await userEvent.type(screen.getByRole('textbox'), 'wor -d');
     await userEvent.click(screen.getByRole('button', { name: 'Done' }));
@@ -50,14 +77,13 @@ describe('MorphemeBreakdownPopover', () => {
   it('does not save when Done is clicked with unchanged text and an existing breakdown', async () => {
     const onSave = jest.fn();
     const onClose = jest.fn();
-    render(
-      <MorphemeBreakdownPopover
-        initialValue="un- believe"
-        onSave={onSave}
-        onClose={onClose}
-        onDelete={jest.fn()}
-      />,
-    );
+    renderPopover({
+      initialValue: 'un- believe',
+      onSave,
+      onClose,
+      onDelete: jest.fn(),
+      surfaceText: 'unbelieve',
+    });
     await userEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(onSave).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -65,32 +91,30 @@ describe('MorphemeBreakdownPopover', () => {
 
   it('saves when Done is clicked with edited text and an existing breakdown', async () => {
     const onSave = jest.fn();
-    render(
-      <MorphemeBreakdownPopover
-        initialValue="un- believe"
-        onSave={onSave}
-        onClose={jest.fn()}
-        onDelete={jest.fn()}
-      />,
-    );
+    renderPopover({
+      initialValue: 'un- believe',
+      onSave,
+      onDelete: jest.fn(),
+      surfaceText: 'unbelieve',
+    });
     await userEvent.type(screen.getByRole('textbox'), ' -r');
     await userEvent.click(screen.getByRole('button', { name: 'Done' }));
     expect(onSave).toHaveBeenCalledWith('un- believe -r');
   });
 
-  it('commits on Enter key', async () => {
+  it('commits a multi-morpheme breakdown on Enter key', async () => {
     const onSave = jest.fn();
     const onClose = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="test" onSave={onSave} onClose={onClose} />);
+    renderPopover({ initialValue: 'te -st', onSave, onClose, surfaceText: 'test' });
     await userEvent.keyboard('{Enter}');
-    expect(onSave).toHaveBeenCalledWith('test');
+    expect(onSave).toHaveBeenCalledWith('te -st');
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   it('dismisses without saving on Escape key', async () => {
     const onSave = jest.fn();
     const onClose = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="test" onSave={onSave} onClose={onClose} />);
+    renderPopover({ initialValue: 'te -st', onSave, onClose, surfaceText: 'test' });
     await userEvent.keyboard('{Escape}');
     expect(onSave).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -99,7 +123,7 @@ describe('MorphemeBreakdownPopover', () => {
   it('dismisses without saving when Cancel button is clicked', async () => {
     const onSave = jest.fn();
     const onClose = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="test" onSave={onSave} onClose={onClose} />);
+    renderPopover({ initialValue: 'te -st', onSave, onClose, surfaceText: 'test' });
     await userEvent.click(screen.getByRole('button', { name: 'Cancel' }));
     expect(onSave).not.toHaveBeenCalled();
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -108,7 +132,7 @@ describe('MorphemeBreakdownPopover', () => {
   it('closes without saving when interacting outside with unchanged text', async () => {
     const onSave = jest.fn();
     const onClose = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="test" onSave={onSave} onClose={onClose} />);
+    renderPopover({ initialValue: 'te -st', onSave, onClose, surfaceText: 'test' });
     // The platform-bible-react mock exposes a sentinel button that fires onInteractOutside,
     // simulating a pointer interaction outside the popover.
     await userEvent.click(screen.getByTestId('popover-outside'));
@@ -118,7 +142,7 @@ describe('MorphemeBreakdownPopover', () => {
 
   it('saves on outside interaction when the text was edited', async () => {
     const onSave = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="test" onSave={onSave} onClose={jest.fn()} />);
+    renderPopover({ initialValue: 'test', onSave, surfaceText: 'whole' });
     await userEvent.type(screen.getByRole('textbox'), ' -er');
     await userEvent.click(screen.getByTestId('popover-outside'));
     expect(onSave).toHaveBeenCalledWith('test -er');
@@ -126,14 +150,14 @@ describe('MorphemeBreakdownPopover', () => {
 
   it('does not save on outside interaction when the input is only whitespace', async () => {
     const onSave = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="   " onSave={onSave} onClose={jest.fn()} />);
+    renderPopover({ initialValue: '   ', onSave });
     await userEvent.click(screen.getByTestId('popover-outside'));
     expect(onSave).not.toHaveBeenCalled();
   });
 
   it('does not dismiss when clicking inside the popover panel', async () => {
     const onClose = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="test" onSave={jest.fn()} onClose={onClose} />);
+    renderPopover({ onClose });
     const label = screen.getByText('Split into morphemes');
     await userEvent.click(label);
     expect(onClose).not.toHaveBeenCalled();
@@ -145,7 +169,13 @@ describe('MorphemeBreakdownPopover', () => {
     const ancestorClick = jest.fn();
     render(
       <div role="presentation" onClick={ancestorClick}>
-        <MorphemeBreakdownPopover initialValue="test" onSave={jest.fn()} onClose={jest.fn()} />
+        <MorphemeBreakdownPopover
+          glossInputId="gloss-1"
+          initialValue="test"
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          surfaceText="word"
+        />
       </div>,
     );
     await userEvent.click(screen.getByText('Split into morphemes'));
@@ -158,29 +188,45 @@ describe('MorphemeBreakdownPopover', () => {
     const ancestorMouseDown = jest.fn();
     render(
       <div role="presentation" onMouseDown={ancestorMouseDown}>
-        <MorphemeBreakdownPopover initialValue="test" onSave={jest.fn()} onClose={jest.fn()} />
+        <MorphemeBreakdownPopover
+          glossInputId="gloss-1"
+          initialValue="test"
+          onClose={jest.fn()}
+          onSave={jest.fn()}
+          surfaceText="word"
+        />
       </div>,
     );
     fireEvent.mouseDown(screen.getByText('Split into morphemes'));
     expect(ancestorMouseDown).not.toHaveBeenCalled();
   });
 
-  it('does not call onSave when the input is empty', async () => {
+  it('disables Done when the input is only whitespace', () => {
+    renderPopover({ initialValue: '   ' });
+    expect(screen.getByRole('button', { name: 'Done' })).toBeDisabled();
+  });
+
+  it('does not save whitespace on Enter', async () => {
     const onSave = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="" onSave={onSave} onClose={jest.fn()} />);
-    await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+    renderPopover({ initialValue: '  ', onSave, surfaceText: 'word' });
+    await userEvent.keyboard('{Enter}');
     expect(onSave).not.toHaveBeenCalled();
   });
 
-  it('does not call onSave when the input is only whitespace', async () => {
+  it('disables Done for a breakdown that is just the whole word as one morpheme', () => {
+    renderPopover({ initialValue: 'word', surfaceText: 'word' });
+    expect(screen.getByRole('button', { name: 'Done' })).toBeDisabled();
+  });
+
+  it('does not save a breakdown that is just the whole word as one morpheme on Enter', async () => {
     const onSave = jest.fn();
-    render(<MorphemeBreakdownPopover initialValue="   " onSave={onSave} onClose={jest.fn()} />);
-    await userEvent.click(screen.getByRole('button', { name: 'Done' }));
+    renderPopover({ initialValue: 'word', onSave, surfaceText: 'word' });
+    await userEvent.keyboard('{Enter}');
     expect(onSave).not.toHaveBeenCalled();
   });
 
   it('does not render a Delete button when onDelete is not provided', () => {
-    render(<MorphemeBreakdownPopover initialValue="test" onSave={jest.fn()} onClose={jest.fn()} />);
+    renderPopover();
     expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
   });
 
@@ -188,14 +234,13 @@ describe('MorphemeBreakdownPopover', () => {
     const onDelete = jest.fn();
     const onSave = jest.fn();
     const onClose = jest.fn();
-    render(
-      <MorphemeBreakdownPopover
-        initialValue="un- believe"
-        onSave={onSave}
-        onClose={onClose}
-        onDelete={onDelete}
-      />,
-    );
+    renderPopover({
+      initialValue: 'un- believe',
+      onSave,
+      onClose,
+      onDelete,
+      surfaceText: 'unbelieve',
+    });
     await userEvent.click(screen.getByRole('button', { name: 'Delete' }));
     expect(onDelete).toHaveBeenCalledTimes(1);
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -205,7 +250,7 @@ describe('MorphemeBreakdownPopover', () => {
   it('renders inside the popover content panel', () => {
     // Positioning, portaling, and flipping are owned by the platform-bible-react Popover; this
     // only verifies the editor renders as the popover's content.
-    render(<MorphemeBreakdownPopover initialValue="test" onSave={jest.fn()} onClose={jest.fn()} />);
+    renderPopover();
     const content = screen.getByTestId('popover-content');
     expect(content).toContainElement(screen.getByText('Split into morphemes'));
   });

--- a/src/__tests__/components/TokenChip.test.tsx
+++ b/src/__tests__/components/TokenChip.test.tsx
@@ -2,6 +2,7 @@
 /// <reference types="jest" />
 /// <reference types="@testing-library/jest-dom" />
 
+import { useLocalizedStrings } from '@papi/frontend/react';
 import { fireEvent, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import type { AssignmentStatus, Token, TokenSnapshot } from 'interlinearizer';
@@ -10,6 +11,15 @@ import { AnalysisStoreProvider } from '../../components/AnalysisStore';
 import { InertTokenChip, TokenChip } from '../../components/TokenChip';
 
 jest.mock('../../components/AnalysisStore');
+
+const LOCALIZED = {
+  '%interlinearizer_tokenChip_editMorphemes%': 'Edit morpheme breakdown for {token}',
+  '%interlinearizer_tokenChip_defineMorphemes%': 'Define morpheme breakdown for {token}',
+};
+
+beforeEach(() => {
+  jest.mocked(useLocalizedStrings).mockReturnValue([LOCALIZED, false]);
+});
 jest.mock('../../components/MorphemeEditor', () => ({
   /**
    * Stub popover that renders a save button so tests can trigger onSave.

--- a/src/components/InterlinearizerLoader.tsx
+++ b/src/components/InterlinearizerLoader.tsx
@@ -226,7 +226,7 @@ function InterlinearizerLoaderInner({
     value: showMorphology,
   } = useOptimisticBooleanSetting(projectId, 'interlinearizer.showMorphology', false);
 
-  // Bundle the display toggles into one stable object. Memoizing on the four primitive values keeps
+  // Bundle the display toggles into one stable object. Memoizing on the primitive values keeps
   // the reference identical across the loader's frequent re-renders (driven by `useData`,
   // `useSetting`, etc.), so the `memo()` wrapping `SegmentView` can shallow-compare it away instead
   // of re-rendering every windowed segment when no toggle actually changed.

--- a/src/components/MorphemeEditor.tsx
+++ b/src/components/MorphemeEditor.tsx
@@ -4,10 +4,22 @@
  *   morpheme forms; {@link MorphemeGlossInput} provides a per-morpheme gloss field.
  */
 import type { MorphemeAnalysis } from 'interlinearizer';
+import { useLocalizedStrings } from '@papi/frontend/react';
 import { PopoverContent } from 'platform-bible-react';
 import { useEffect, useId, useRef, useState } from 'react';
 import type { KeyboardEvent, MouseEvent } from 'react';
 import { useMorphemeGlossDispatch } from './AnalysisStore';
+
+const POPOVER_STRING_KEYS = [
+  '%interlinearizer_morphemeEditor_splitLabel%',
+  '%interlinearizer_morphemeEditor_delete%',
+  '%interlinearizer_morphemeEditor_cancel%',
+  '%interlinearizer_morphemeEditor_done%',
+] as const satisfies `%${string}%`[];
+
+const MORPHEME_GLOSS_STRING_KEYS = [
+  '%interlinearizer_morphemeGloss_label%',
+] as const satisfies `%${string}%`[];
 
 /**
  * Inline popover for defining or editing a token's morpheme breakdown. The user types
@@ -15,9 +27,9 @@ import { useMorphemeGlossDispatch } from './AnalysisStore';
  * clicking outside the popover (matching the commit-on-blur behavior of gloss inputs). Cancel and
  * Escape dismiss without saving. An unedited draft is never re-saved over an existing breakdown —
  * Enter, Done, and outside clicks all dismiss instead, because re-saving identical forms would only
- * rewrite identical data. When no breakdown exists yet, Enter and Done with the unedited pre-filled
- * surface text deliberately record the token as a single whole-word morpheme, but an outside click
- * dismisses without saving so an accidental click cannot create one.
+ * rewrite identical data. A breakdown that is empty or just the whole word as a single morpheme
+ * carries no real segmentation, so it is never saved either: the Done button is disabled for it and
+ * the Enter / outside-click paths dismiss without writing.
  *
  * Renders the content of a `platform-bible-react` `Popover`; the caller owns the `Popover` root and
  * the `PopoverAnchor` the panel is positioned from, and must render this component only while the
@@ -33,6 +45,10 @@ import { useMorphemeGlossDispatch } from './AnalysisStore';
  *   token's existing morpheme breakdown, then dismisses the popover. Callers should omit it when
  *   the token has no breakdown to delete; its presence is also how the popover knows a breakdown
  *   already exists when deciding whether an unedited commit should save.
+ * @param props.surfaceText - The token's surface text, used to reject a "breakdown" that is just
+ *   the whole word as a single morpheme (no real segmentation).
+ * @param props.glossInputId - Id of the token's gloss input; focus is restored to it when the
+ *   popover closes, rather than to the non-tabbable morpheme trigger.
  * @returns A popover panel with a text input and Cancel/Done buttons.
  */
 export function MorphemeBreakdownPopover({
@@ -40,12 +56,17 @@ export function MorphemeBreakdownPopover({
   onSave,
   onClose,
   onDelete,
+  surfaceText,
+  glossInputId,
 }: Readonly<{
   initialValue: string;
   onSave: (value: string) => void;
   onClose: () => void;
   onDelete?: () => void;
+  surfaceText: string;
+  glossInputId: string;
 }>) {
+  const [localizedStrings] = useLocalizedStrings(POPOVER_STRING_KEYS);
   const inputId = useId();
   const [draft, setDraft] = useState(initialValue);
   // eslint-disable-next-line no-null/no-null
@@ -72,15 +93,24 @@ export function MorphemeBreakdownPopover({
   // comparing normalized text avoids a no-op persistence round-trip.
   const isUnedited = normalize(draft) === normalize(initialValue);
 
+  // A breakdown carries no real segmentation when it is empty or is just the whole word as a single
+  // morpheme equal to the surface text; in both cases there is nothing worth persisting.
+  const normalized = normalize(draft);
+  const forms = normalized === '' ? [] : normalized.split(' ');
+  const isMeaningless = forms.length === 0 || (forms.length === 1 && forms[0] === surfaceText);
+
   /**
-   * Commits the current draft and closes the popover. Skips the save when the token already has a
+   * Commits the current draft and closes the popover. Skips the save when the breakdown is
+   * meaningless (empty, or the whole word as one morpheme), or when the token already has a
    * breakdown (`onDelete` provided) and the text was not edited — re-saving identical forms would
-   * only rewrite identical data. An unedited commit on a token with _no_ breakdown is kept: it
-   * deliberately records the token as a single whole-word morpheme.
+   * only rewrite identical data.
    */
   const handleSave = () => {
-    const trimmed = draft.trim();
-    if (trimmed && !(onDelete && isUnedited)) onSave(trimmed);
+    if (isMeaningless || (onDelete && isUnedited)) {
+      onClose();
+      return;
+    }
+    onSave(draft.trim());
     onClose();
   };
 
@@ -98,10 +128,9 @@ export function MorphemeBreakdownPopover({
 
   /**
    * Commits the draft when the user interacts outside the popover, except when the text was not
-   * edited — then the interaction acts like Cancel. Unlike Enter and Done, the unedited check here
-   * applies even when the token has no breakdown yet ({@link handleSave} would otherwise create a
-   * single-morpheme breakdown equal to the pre-filled surface text), because an accidental outside
-   * click is not a deliberate commit.
+   * edited — then the interaction acts like Cancel, because an accidental outside click is not a
+   * deliberate commit. An edited-but-meaningless draft is also dismissed without saving by
+   * {@link handleSave}.
    */
   const handleInteractOutside = () => {
     if (isUnedited) {
@@ -134,9 +163,15 @@ export function MorphemeBreakdownPopover({
       onEscapeKeyDown={onClose}
       onInteractOutside={handleInteractOutside}
       onOpenAutoFocus={(e) => e.preventDefault()}
+      onCloseAutoFocus={(e) => {
+        // Restore focus to the token's gloss input rather than the non-tabbable morpheme trigger
+        // (Radix's default). preventScroll keeps the React-controlled scroll the sole scroller.
+        e.preventDefault();
+        document.getElementById(glossInputId)?.focus({ preventScroll: true });
+      }}
     >
       <label className="tw:text-xs tw:text-muted-foreground" htmlFor={inputId}>
-        Split into morphemes
+        {localizedStrings['%interlinearizer_morphemeEditor_splitLabel%']}
       </label>
       <input
         ref={inputRef}
@@ -157,7 +192,7 @@ export function MorphemeBreakdownPopover({
               onClose();
             }}
           >
-            Delete
+            {localizedStrings['%interlinearizer_morphemeEditor_delete%']}
           </button>
         )}
         <button
@@ -165,14 +200,15 @@ export function MorphemeBreakdownPopover({
           type="button"
           onClick={onClose}
         >
-          Cancel
+          {localizedStrings['%interlinearizer_morphemeEditor_cancel%']}
         </button>
         <button
-          className="tw:rounded tw:bg-primary tw:px-3 tw:py-0.5 tw:text-xs tw:text-primary-foreground tw:hover:bg-primary/90"
+          className="tw:rounded tw:bg-primary tw:px-3 tw:py-0.5 tw:text-xs tw:text-primary-foreground tw:hover:bg-primary/90 tw:disabled:opacity-50 tw:disabled:pointer-events-none"
+          disabled={isMeaningless}
           type="button"
           onClick={handleSave}
         >
-          Done
+          {localizedStrings['%interlinearizer_morphemeEditor_done%']}
         </button>
       </div>
     </PopoverContent>
@@ -206,6 +242,7 @@ export function MorphemeGlossInput({
   const committed = morpheme.gloss?.[analysisLanguage] ?? '';
   const dispatchMorphemeGloss = useMorphemeGlossDispatch();
   const [draft, setDraft] = useState(committed);
+  const [localizedStrings] = useLocalizedStrings(MORPHEME_GLOSS_STRING_KEYS);
 
   useEffect(() => {
     setDraft(committed);
@@ -213,7 +250,10 @@ export function MorphemeGlossInput({
 
   return (
     <input
-      aria-label={`Gloss for morpheme ${morpheme.form}`}
+      aria-label={localizedStrings['%interlinearizer_morphemeGloss_label%'].replace(
+        '{form}',
+        morpheme.form,
+      )}
       className="tw:gloss-input tw:text-xs"
       data-morpheme-gloss="true"
       disabled={disabled}

--- a/src/components/MorphemeEditor.tsx
+++ b/src/components/MorphemeEditor.tsx
@@ -47,8 +47,9 @@ const MORPHEME_GLOSS_STRING_KEYS = [
  *   already exists when deciding whether an unedited commit should save.
  * @param props.surfaceText - The token's surface text, used to reject a "breakdown" that is just
  *   the whole word as a single morpheme (no real segmentation).
- * @param props.glossInputId - Id of the token's gloss input; focus is restored to it when the
- *   popover closes, rather than to the non-tabbable morpheme trigger.
+ * @param props.glossInputId - Id of the token's gloss input; used to locate the chip on close so
+ *   focus lands on its first morpheme gloss field (falling back to the gloss input itself), rather
+ *   than on the non-tabbable morpheme trigger.
  * @returns A popover panel with a text input and Cancel/Done buttons.
  */
 export function MorphemeBreakdownPopover({
@@ -164,10 +165,18 @@ export function MorphemeBreakdownPopover({
       onInteractOutside={handleInteractOutside}
       onOpenAutoFocus={(e) => e.preventDefault()}
       onCloseAutoFocus={(e) => {
-        // Restore focus to the token's gloss input rather than the non-tabbable morpheme trigger
-        // (Radix's default). preventScroll keeps the React-controlled scroll the sole scroller.
+        // On close, land focus on the chip's first morpheme gloss field rather than Radix's default
+        // (the non-tabbable trigger). The morpheme gloss inputs sit before the token gloss input
+        // inside the same label, so scope the lookup to that label — the panel is portaled to
+        // document.body, so a document-wide query could match another token's field. Fall back to
+        // the token gloss input when no morpheme field exists (dismissed with no breakdown, or
+        // deleted). preventScroll keeps the React-controlled scroll the sole scroller.
         e.preventDefault();
-        document.getElementById(glossInputId)?.focus({ preventScroll: true });
+        const glossInput = document.getElementById(glossInputId);
+        const firstMorphemeGloss = glossInput
+          ?.closest('label')
+          ?.querySelector<HTMLInputElement>('input[data-morpheme-gloss]');
+        (firstMorphemeGloss ?? glossInput)?.focus({ preventScroll: true });
       }}
     >
       <label className="tw:text-xs tw:text-muted-foreground" htmlFor={inputId}>

--- a/src/components/MorphemeEditor.tsx
+++ b/src/components/MorphemeEditor.tsx
@@ -156,29 +156,35 @@ export function MorphemeBreakdownPopover({
     e.stopPropagation();
   };
 
+  /**
+   * Overrides Radix's default close-focus behavior to land focus on the chip's first morpheme gloss
+   * field. The morpheme gloss inputs sit before the token gloss input inside the same label, so the
+   * lookup is scoped to that label — the panel is portaled to `document.body`, so a document-wide
+   * query could match another token's field. Falls back to the token gloss input when no morpheme
+   * field exists (dismissed with no breakdown, or deleted).
+   *
+   * @param e - The Radix close auto-focus event.
+   */
+  const handleCloseAutoFocus = (e: Event) => {
+    e.preventDefault();
+    const glossInput = document.getElementById(glossInputId);
+    const firstMorphemeGloss = glossInput
+      ?.closest('label')
+      ?.querySelector<HTMLInputElement>('input[data-morpheme-gloss]');
+    // `preventScroll` keeps the React-controlled scroll the sole scroller.
+    (firstMorphemeGloss ?? glossInput)?.focus({ preventScroll: true });
+  };
+
   return (
     <PopoverContent
       align="start"
       className="tw:flex tw:w-auto tw:min-w-48 tw:flex-col tw:gap-1.5 tw:p-2"
       onClick={stopMouseEvents}
-      onMouseDown={stopMouseEvents}
+      onCloseAutoFocus={handleCloseAutoFocus}
       onEscapeKeyDown={onClose}
       onInteractOutside={handleInteractOutside}
+      onMouseDown={stopMouseEvents}
       onOpenAutoFocus={(e) => e.preventDefault()}
-      onCloseAutoFocus={(e) => {
-        // On close, land focus on the chip's first morpheme gloss field rather than Radix's default
-        // (the non-tabbable trigger). The morpheme gloss inputs sit before the token gloss input
-        // inside the same label, so scope the lookup to that label — the panel is portaled to
-        // document.body, so a document-wide query could match another token's field. Fall back to
-        // the token gloss input when no morpheme field exists (dismissed with no breakdown, or
-        // deleted). preventScroll keeps the React-controlled scroll the sole scroller.
-        e.preventDefault();
-        const glossInput = document.getElementById(glossInputId);
-        const firstMorphemeGloss = glossInput
-          ?.closest('label')
-          ?.querySelector<HTMLInputElement>('input[data-morpheme-gloss]');
-        (firstMorphemeGloss ?? glossInput)?.focus({ preventScroll: true });
-      }}
     >
       <label className="tw:text-xs tw:text-muted-foreground" htmlFor={inputId}>
         {localizedStrings['%interlinearizer_morphemeEditor_splitLabel%']}

--- a/src/components/MorphemeEditor.tsx
+++ b/src/components/MorphemeEditor.tsx
@@ -98,7 +98,8 @@ export function MorphemeBreakdownPopover({
   // morpheme equal to the surface text; in both cases there is nothing worth persisting.
   const normalized = normalize(draft);
   const forms = normalized === '' ? [] : normalized.split(' ');
-  const isMeaningless = forms.length === 0 || (forms.length === 1 && forms[0] === surfaceText);
+  const isMeaningless =
+    forms.length === 0 || (forms.length === 1 && forms[0] === normalize(surfaceText));
 
   /**
    * Commits the current draft and closes the popover. Skips the save when the breakdown is
@@ -261,7 +262,7 @@ export function MorphemeGlossInput({
     <input
       aria-label={localizedStrings['%interlinearizer_morphemeGloss_label%'].replace(
         '{form}',
-        morpheme.form,
+        () => morpheme.form,
       )}
       className="tw:gloss-input tw:text-xs"
       data-morpheme-gloss="true"

--- a/src/components/TokenChip.tsx
+++ b/src/components/TokenChip.tsx
@@ -1,4 +1,5 @@
 import type { Token } from 'interlinearizer';
+import { useLocalizedStrings } from '@papi/frontend/react';
 import { X } from 'lucide-react';
 import { Popover, PopoverAnchor } from 'platform-bible-react';
 import { memo, type MouseEventHandler, useEffect, useId, useRef, useState } from 'react';
@@ -11,6 +12,11 @@ import {
   useMorphemes,
 } from './AnalysisStore';
 import { MorphemeBreakdownPopover, MorphemeGlossInput } from './MorphemeEditor';
+
+const STRING_KEYS = [
+  '%interlinearizer_tokenChip_editMorphemes%',
+  '%interlinearizer_tokenChip_defineMorphemes%',
+] as const satisfies `%${string}%`[];
 
 /**
  * Renders a single word token as an inline chip with an editable gloss input below the surface
@@ -51,6 +57,7 @@ export function TokenChip({
   isSplitFree?: boolean;
   showMorphology?: boolean;
 }>) {
+  const [localizedStrings] = useLocalizedStrings(STRING_KEYS);
   const committedGloss = useGloss(token.ref);
   const onGlossChange = useGlossDispatch();
   const morphemes = useMorphemes(token.ref);
@@ -172,12 +179,11 @@ export function TokenChip({
             <PopoverAnchor asChild>
               <div className="tw:relative tw:flex tw:flex-col tw:items-center tw:w-full">
                 <button
-                  aria-label={
-                    hasMorphemes
-                      ? `Edit morpheme breakdown for ${token.surfaceText}`
-                      : `Define morpheme breakdown for ${token.surfaceText}`
-                  }
-                  className={`tw:flex tw:flex-row tw:gap-0.5 tw:items-center tw:rounded tw:px-0.5 tw:cursor-pointer tw:transition-colors tw:hover:bg-accent ${hasMorphemes ? 'tw:text-muted-foreground' : 'tw:text-muted-foreground/50 tw:italic'}`}
+                  aria-label={(hasMorphemes
+                    ? localizedStrings['%interlinearizer_tokenChip_editMorphemes%']
+                    : localizedStrings['%interlinearizer_tokenChip_defineMorphemes%']
+                  ).replace('{token}', token.surfaceText)}
+                  className={`tw:flex tw:flex-row tw:gap-0.5 tw:items-center tw:rounded tw:px-0.5 tw:transition-colors${disabled ? '' : ' tw:cursor-pointer tw:hover:bg-accent'} ${hasMorphemes ? 'tw:text-muted-foreground' : 'tw:text-muted-foreground/50 tw:italic'}`}
                   tabIndex={-1}
                   type="button"
                   onClick={(e) => {
@@ -214,12 +220,14 @@ export function TokenChip({
             </PopoverAnchor>
             {popoverOpen && (
               <MorphemeBreakdownPopover
+                glossInputId={glossInputId}
                 initialValue={
                   hasMorphemes ? morphemes.map((m) => m.form).join(' ') : token.surfaceText
                 }
                 onClose={() => setPopoverOpen(false)}
                 onDelete={hasMorphemes ? () => dispatchMorphemeDelete(token.ref) : undefined}
                 onSave={handleMorphemeSave}
+                surfaceText={token.surfaceText}
               />
             )}
           </Popover>

--- a/src/main.ts
+++ b/src/main.ts
@@ -362,9 +362,16 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     },
   );
 
-  // All interlinearizer view-toggle settings are booleans, so they share one validator.
-  /* v8 ignore next */
-  const isBoolean = async (newValue: unknown) => typeof newValue === 'boolean';
+  /**
+   * Returns whether the supplied project-setting value is a boolean.
+   *
+   * @param newValue - Candidate project-setting value.
+   * @returns A promise that resolves to `true` when `newValue` is a boolean.
+   */
+  /* v8 ignore next 3 */
+  function isBoolean(newValue: unknown): Promise<boolean> {
+    return Promise.resolve(typeof newValue === 'boolean');
+  }
 
   const continuousScrollValidatorRegistration = await papi.projectSettings.registerValidator(
     'interlinearizer.continuousScroll',

--- a/src/main.ts
+++ b/src/main.ts
@@ -362,29 +362,32 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
     },
   );
 
+  // All interlinearizer view-toggle settings are booleans, so they share one validator.
+  const isBoolean = async (newValue: unknown) => typeof newValue === 'boolean';
+
   const continuousScrollValidatorRegistration = await papi.projectSettings.registerValidator(
     'interlinearizer.continuousScroll',
-    async (newValue) => typeof newValue === 'boolean',
+    isBoolean,
   );
 
   const hideInactiveLinkButtonsValidatorRegistration = await papi.projectSettings.registerValidator(
     'interlinearizer.hideInactiveLinkButtons',
-    async (newValue) => typeof newValue === 'boolean',
+    isBoolean,
   );
 
   const simplifyPhrasesValidatorRegistration = await papi.projectSettings.registerValidator(
     'interlinearizer.simplifyPhrases',
-    async (newValue) => typeof newValue === 'boolean',
+    isBoolean,
   );
 
   const chapterLabelInVerseValidatorRegistration = await papi.projectSettings.registerValidator(
     'interlinearizer.chapterLabelInVerse',
-    async (newValue) => typeof newValue === 'boolean',
+    isBoolean,
   );
 
   const showMorphologyValidatorRegistration = await papi.projectSettings.registerValidator(
     'interlinearizer.showMorphology',
-    async (newValue) => typeof newValue === 'boolean',
+    isBoolean,
   );
 
   const createProjectCommandRegistration = await papi.commands.registerCommand(

--- a/src/main.ts
+++ b/src/main.ts
@@ -363,6 +363,7 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
   );
 
   // All interlinearizer view-toggle settings are booleans, so they share one validator.
+  /* v8 ignore next */
   const isBoolean = async (newValue: unknown) => typeof newValue === 'boolean';
 
   const continuousScrollValidatorRegistration = await papi.projectSettings.registerValidator(

--- a/src/store/analysisSlice.ts
+++ b/src/store/analysisSlice.ts
@@ -191,6 +191,13 @@ function removeTokenAnalysis(
  * when it has no entries or every entry is blank, so a record left holding only whitespace glosses
  * (junk from clearing a gloss field) is treated the same as one with no gloss at all.
  *
+ * Provenance fields (`confidence`, `producer`, `sourceUser`) are intentionally NOT treated as
+ * content: they describe who/what produced an analysis, not an analysis worth keeping on their own.
+ * A record holding only provenance and no glosses/morphemes/pos/features is therefore considered
+ * empty and may be dropped when its last content field is cleared. This is a deliberate choice — if
+ * a future workflow needs provenance-only records (e.g. imported parser metadata) to survive a gloss
+ * clear, add the relevant fields to the check below.
+ *
  * @param analysis - The `TokenAnalysis` to inspect.
  * @returns `true` when the record holds no analysis content worth keeping.
  */

--- a/src/types/type-guards.ts
+++ b/src/types/type-guards.ts
@@ -75,8 +75,9 @@ function isTokenSnapshot(v: unknown): boolean {
 }
 
 /**
- * Checks that `v` satisfies the base `Analysis` shape (`id` and `surfaceText`). Used as the
- * `.every()` predicate for `segmentAnalyses`, `tokenAnalyses`, and `phraseAnalyses`.
+ * Checks that `v` satisfies the base `Analysis` shape (`id` and `surfaceText`). Used directly as
+ * the `.every()` predicate for `segmentAnalyses` and `phraseAnalyses`, and as the base of
+ * {@link isTokenAnalysisRecord} for `tokenAnalyses`.
  *
  * @param v - The value to test.
  * @returns `true` if `v` is an object with string `id` and `surfaceText` properties.
@@ -89,6 +90,45 @@ function isAnalysisRecord(v: unknown): boolean {
     typeof v.id === 'string' &&
     'surfaceText' in v &&
     typeof v.surfaceText === 'string'
+  );
+}
+
+/**
+ * Checks that `v` has the required fields of a `MorphemeAnalysis` (`id`, `form`, `writingSystem`).
+ * Used to validate the elements of a `TokenAnalysis.morphemes` array at the persistence boundary.
+ *
+ * @param v - The value to test.
+ * @returns `true` if `v` is an object with string `id`, `form`, and `writingSystem` properties.
+ */
+function isMorphemeAnalysis(v: unknown): boolean {
+  return (
+    !!v &&
+    typeof v === 'object' &&
+    'id' in v &&
+    typeof v.id === 'string' &&
+    'form' in v &&
+    typeof v.form === 'string' &&
+    'writingSystem' in v &&
+    typeof v.writingSystem === 'string'
+  );
+}
+
+/**
+ * Checks that `v` satisfies the `TokenAnalysis` shape: the base `Analysis` fields plus, when
+ * present, a `morphemes` array whose every element passes {@link isMorphemeAnalysis}. Morphemes are
+ * first-class data read by the UI (`m.id` keys, `m.form`, `m.writingSystem`), so a malformed array
+ * must be rejected before persisting rather than surfacing as a render-time fault.
+ *
+ * @param v - The value to test.
+ * @returns `true` if `v` is a valid analysis record with a well-formed (or absent) `morphemes`
+ *   array.
+ */
+function isTokenAnalysisRecord(v: unknown): boolean {
+  return (
+    isAnalysisRecord(v) &&
+    !!v &&
+    typeof v === 'object' &&
+    (!('morphemes' in v) || (Array.isArray(v.morphemes) && v.morphemes.every(isMorphemeAnalysis)))
   );
 }
 
@@ -181,7 +221,7 @@ export function isTextAnalysis(value: unknown): value is TextAnalysis {
     value.segmentAnalysisLinks.every(isSegmentAnalysisLink) &&
     'tokenAnalyses' in value &&
     Array.isArray(value.tokenAnalyses) &&
-    value.tokenAnalyses.every(isAnalysisRecord) &&
+    value.tokenAnalyses.every(isTokenAnalysisRecord) &&
     'tokenAnalysisLinks' in value &&
     Array.isArray(value.tokenAnalysisLinks) &&
     value.tokenAnalysisLinks.every(isTokenAnalysisLink) &&


### PR DESCRIPTION
Suggested modifications on #104

Devin: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/111

## Summary of changes

- **Don't save meaningless morpheme breakdowns.** A breakdown that is empty or just the whole word as a single morpheme carries no real segmentation, so the **Done** button is disabled for it and the Enter / outside-click commit paths dismiss without writing.
- **Localization.** Morpheme-editor strings and the morpheme-gloss + token morpheme-trigger aria-labels now go through `useLocalizedStrings` (with `{form}` / `{token}` interpolation); new keys added to `localizedStrings.json`.
- **Validate morpheme shape at the persistence boundary.** `isTextAnalysis` now rejects malformed `morphemes` via new `isTokenAnalysisRecord` / `isMorphemeAnalysis` guards.
- **Focus restore.** Closing the morpheme popover returns focus to the first morpheme gloss.
- **Disabled morpheme trigger** no longer shows a pointer/hover affordance.
- **De-duplicate** the five identical boolean project-setting validators into one shared `isBoolean`.
- **Docs.** Document the deliberate provenance-field exclusion in `isEmptyTokenAnalysis`; de-stale the `viewOptions` memo comment.
- Tests updated accordingly.

Devin: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/111)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added localized string labels for morpheme editing UI controls.

* **Improvements**
  * Enhanced focus management when closing the morpheme editor popup.
  * Validation now prevents saving empty or meaningless morpheme breakdowns; the Done button is disabled for such drafts.
  * Strengthened morpheme analysis validation for data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->