### PR TITLE
Fix confirmation overlay not closing properly when errors occur

### DIFF
--- a/src/components/modals/ProjectModals.tsx
+++ b/src/components/modals/ProjectModals.tsx
@@ -270,8 +270,9 @@ export default function ProjectModals({
       }
     } finally {
       setIsReplacing(false);
+      // Cleared in finally so the dialog dismisses even if openProject or startNewDraft ever throws.
+      setPendingReplace(undefined);
     }
-    setPendingReplace(undefined);
   }, [isReplacing, openProject, pendingReplace, startNewDraft]);
 
   /** Cancels the deferred action, returning to the underlying modal with the draft untouched. */
@@ -408,6 +409,9 @@ export default function ProjectModals({
     setMetadataProject(undefined);
   }, [metadataSourceIsSelect, setModal]);
 
+  // Read the draft snapshot at render time rather than inside SaveAsProjectModal's mount effect.
+  // getDraftSnapshot reads a ref synchronously (no allocation), so it is effectively free every
+  // render. The value is only consumed when modal === 'saveAs'; it does not drive any other branch.
   const draftSnapshot = getDraftSnapshot();
 
   return (

--- a/src/components/modals/ProjectModals.tsx
+++ b/src/components/modals/ProjectModals.tsx
@@ -270,7 +270,6 @@ export default function ProjectModals({
       }
     } finally {
       setIsReplacing(false);
-      // Cleared in finally so the dialog dismisses even if openProject or startNewDraft ever throws.
       setPendingReplace(undefined);
     }
   }, [isReplacing, openProject, pendingReplace, startNewDraft]);
@@ -409,9 +408,6 @@ export default function ProjectModals({
     setMetadataProject(undefined);
   }, [metadataSourceIsSelect, setModal]);
 
-  // Read the draft snapshot at render time rather than inside SaveAsProjectModal's mount effect.
-  // getDraftSnapshot reads a ref synchronously (no allocation), so it is effectively free every
-  // render. The value is only consumed when modal === 'saveAs'; it does not drive any other branch.
   const draftSnapshot = getDraftSnapshot();
 
   return (

--- a/src/components/modals/SaveAsProjectModal.tsx
+++ b/src/components/modals/SaveAsProjectModal.tsx
@@ -219,6 +219,9 @@ export function SaveAsProjectModal({
                     {project.analysisLanguages.join(', ')}
                   </span>
                 </span>
+                {/* Clicking this button only opens the inline confirmation dialog; the actual
+                    overwrite is triggered by the confirm button inside that panel. Disabled while
+                    submitting to prevent switching the pending target mid-save. */}
                 <Button
                   variant="secondary"
                   size="sm"

--- a/src/components/modals/SaveAsProjectModal.tsx
+++ b/src/components/modals/SaveAsProjectModal.tsx
@@ -219,9 +219,6 @@ export function SaveAsProjectModal({
                     {project.analysisLanguages.join(', ')}
                   </span>
                 </span>
-                {/* Clicking this button only opens the inline confirmation dialog; the actual
-                    overwrite is triggered by the confirm button inside that panel. Disabled while
-                    submitting to prevent switching the pending target mid-save. */}
                 <Button
                   variant="secondary"
                   size="sm"

--- a/src/hooks/useDraftProject.ts
+++ b/src/hooks/useDraftProject.ts
@@ -135,6 +135,13 @@ export default function useDraftProject(
    * Persists `draft` to storage, fire-and-forget. The backend surfaces an error notification on
    * failure; here we only log so a rejected write never throws into a render or event handler.
    *
+   * Note: the draft is the **only** persistence path — there is no secondary write on blur or
+   * unmount that would retry a failed autosave. If storage is unavailable during editing, the backend
+   * sends one error notification per failed write (the user's signal); if that notification itself
+   * fails (the `.catch(() => {})` in `main.ts`), edits made in that window are silently lost on the
+   * next page refresh. The tab title's `●` marker stays lit because `dirty` is set optimistically
+   * before the write, not in response to its outcome.
+   *
    * @param draft - The draft envelope to write.
    */
   const persist = useCallback(
@@ -146,6 +153,11 @@ export default function useDraftProject(
     [sourceProjectId],
   );
 
+  // Note: when sourceProjectId changes, setIsDraftLoading(true) fires immediately but `dirty`
+  // retains its old value until the new draft loads and setDirty runs. During that brief window
+  // hasUnsavedChanges in InterlinearizerLoader uses the stale value, so the tab title may flash a
+  // stale `●`. This self-corrects once the load finishes and is nearly unreachable in practice
+  // because a projectId change from the PAPI host typically triggers a full WebView remount.
   useEffect(() => {
     let canceled = false;
     setIsDraftLoading(true);

--- a/src/hooks/useDraftProject.ts
+++ b/src/hooks/useDraftProject.ts
@@ -136,11 +136,11 @@ export default function useDraftProject(
    * failure; here we only log so a rejected write never throws into a render or event handler.
    *
    * Note: the draft is the **only** persistence path — there is no secondary write on blur or
-   * unmount that would retry a failed autosave. If storage is unavailable during editing, the backend
-   * sends one error notification per failed write (the user's signal); if that notification itself
-   * fails (the `.catch(() => {})` in `main.ts`), edits made in that window are silently lost on the
-   * next page refresh. The tab title's `●` marker stays lit because `dirty` is set optimistically
-   * before the write, not in response to its outcome.
+   * unmount that would retry a failed autosave. If storage is unavailable during editing, the
+   * backend sends one error notification per failed write; if that notification itself fails (the
+   * `.catch(() => {})` in `main.ts`), edits made in that window are silently lost on the next page
+   * refresh. The tab title's `●` marker stays lit because `dirty` is set optimistically before the
+   * write, not in response to its outcome.
    *
    * @param draft - The draft envelope to write.
    */
@@ -153,11 +153,6 @@ export default function useDraftProject(
     [sourceProjectId],
   );
 
-  // Note: when sourceProjectId changes, setIsDraftLoading(true) fires immediately but `dirty`
-  // retains its old value until the new draft loads and setDirty runs. During that brief window
-  // hasUnsavedChanges in InterlinearizerLoader uses the stale value, so the tab title may flash a
-  // stale `●`. This self-corrects once the load finishes and is nearly unreachable in practice
-  // because a projectId change from the PAPI host typically triggers a full WebView remount.
   useEffect(() => {
     let canceled = false;
     setIsDraftLoading(true);


### PR DESCRIPTION
Devin: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/120

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/120)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed confirmation overlay not closing properly when errors occur during project operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->