### PR TITLE
Add modification timestamps to projects

### DIFF
--- a/contributions/localizedStrings.json
+++ b/contributions/localizedStrings.json
@@ -65,6 +65,7 @@
       "%interlinearizer_modal_metadata_description_label%": "Description",
       "%interlinearizer_modal_metadata_description_placeholder%": "e.g. Token-level English glosses",
       "%interlinearizer_modal_metadata_created_label%": "Created",
+      "%interlinearizer_modal_metadata_modified_label%": "Modified",
       "%interlinearizer_modal_metadata_source_label%": "Source Project",
       "%interlinearizer_modal_metadata_analysis_language_label%": "Analysis Language",
       "%interlinearizer_modal_metadata_language_placeholder%": "e.g. en",
@@ -81,6 +82,7 @@
       "%interlinearizer_modal_select_name_unnamed%": "Unnamed",
       "%interlinearizer_modal_select_info_button_label%": "Project info",
       "%interlinearizer_modal_select_active_badge%": "Active",
+      "%interlinearizer_modal_select_modified_prefix%": "Modified",
       "%interlinearizer_modal_select_create_new%": "Create New",
       "%interlinearizer_modal_select_cancel%": "Cancel",
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -2395,9 +2395,9 @@
       }
     },
     "node_modules/@nodable/entities": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
-      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+      "integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
       "funding": [
         {
           "type": "github",
@@ -3208,49 +3208,49 @@
       }
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
-      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.3.tgz",
+      "integrity": "sha512-/T8IKEsf9VTU6tLjgC7+sv2mOPtQxzE2jMw7u4Tt40Tx+QSZxpzh95/H6cMKoja9XuW7iMdLJYBB0o9G1CaAgg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "5.21.6",
+        "enhanced-resolve": "^5.24.1",
         "jiti": "^2.7.0",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.3.2"
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
-      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.3.tgz",
+      "integrity": "sha512-krXjAikiaFSPaK/FkAQT5UTx3VormQaiZ5hBFlJZ9UFQGB/rwg1MZIhHAG9smMQRTdyJxP6Qt5MwMtdyU5FWrA==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
-        "@tailwindcss/oxide-darwin-x64": "4.3.2",
-        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
-        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
-        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+        "@tailwindcss/oxide-android-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.3",
+        "@tailwindcss/oxide-darwin-x64": "4.3.3",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.3",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.3",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.3",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.3",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.3",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
-      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.3.tgz",
+      "integrity": "sha512-Y85A2gmPSkl5Ve5qR86GL4HT509cFqQh1aes9p3sSkyTPwt0Pppf3GkwGe4JPACcRYjgJIEhQgM6dBClnr0NYw==",
       "cpu": [
         "arm64"
       ],
@@ -3265,9 +3265,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
-      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.3.tgz",
+      "integrity": "sha512-BiaWatpBcERQFDlOjRDpIVXuFK5PJez5SA4JMg6VYZdBYU+qKfV/vqjcIs+IYmtitf1xYQZTwXvU/8y4lfZUGw==",
       "cpu": [
         "arm64"
       ],
@@ -3282,9 +3282,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
-      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.3.tgz",
+      "integrity": "sha512-fAeUqfV5ndhxRwai8cXGzdLvul9utWOmeTkv69unv4ZXixjn61Z+p9lCWdwOwA3TYboG3BwdVuN/RDjhBRl0mw==",
       "cpu": [
         "x64"
       ],
@@ -3299,9 +3299,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
-      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.3.tgz",
+      "integrity": "sha512-iyf5bV6+wnAlflVeEy7R25dupxTNECZN5QMI0qNT6eT+EgaGdZcKhGkr5SdoaWiLJ3spLqIY9VCeSGrwmtg4kw==",
       "cpu": [
         "x64"
       ],
@@ -3316,9 +3316,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
-      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.3.tgz",
+      "integrity": "sha512-aAYUprJAJQWWbRrPvtjdroZ56Md+JM8pMiopS6xGEwDfLhqj+2ver2p4nU4Mb3CRqcMmNBjo8KkUgcxhkzVQGQ==",
       "cpu": [
         "arm"
       ],
@@ -3333,9 +3333,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
-      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.3.tgz",
+      "integrity": "sha512-nDxldcEENOxZRzC2uu9jrutZdAAQtb+8WWDCSnWL1zvBk1+FN+x6MtDViPB5AJMfttVCUhehGWus3XBPgatM/w==",
       "cpu": [
         "arm64"
       ],
@@ -3350,9 +3350,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
-      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.3.tgz",
+      "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
       ],
@@ -3367,9 +3367,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
-      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.3.tgz",
+      "integrity": "sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==",
       "cpu": [
         "x64"
       ],
@@ -3384,9 +3384,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
-      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.3.tgz",
+      "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
       ],
@@ -3401,9 +3401,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
-      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.3.tgz",
+      "integrity": "sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -3431,9 +3431,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
-      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.3.tgz",
+      "integrity": "sha512-3rc292Ca2ceK6Ulcc/bAVnTs/3nDtoPhyEKlgPv+yQJQi/JS/AMJlqzxvlDacL1nekbrcf6bTqp/jV4qgnPxNQ==",
       "cpu": [
         "arm64"
       ],
@@ -3448,9 +3448,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
-      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.3.tgz",
+      "integrity": "sha512-yJ0pwIVc/nYeGoV02WtsN8KYyLQv7kyI2wDnkezyJlGGjkd4QLwDGAwl47YpPJeuI0M0ObaXGSPjvWDPeTPggw==",
       "cpu": [
         "x64"
       ],
@@ -3465,17 +3465,17 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
-      "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.3.tgz",
+      "integrity": "sha512-JTSZZGQi1AyKirbLN3azmjVzef92tcX7h+iSqPdaeStyFpGpDlKvvpxeOE8njhbUanbRwr3z8DyzhICWnMtQeg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.3.2",
-        "@tailwindcss/oxide": "4.3.2",
-        "postcss": "^8.5.15",
-        "tailwindcss": "4.3.2"
+        "@tailwindcss/node": "4.3.3",
+        "@tailwindcss/oxide": "4.3.3",
+        "postcss": "^8.5.16",
+        "tailwindcss": "4.3.3"
       }
     },
     "node_modules/@tailwindcss/typography": {
@@ -5804,9 +5804,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001805",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001805.tgz",
-      "integrity": "sha512-52noaS3DubycKSXaU30TwPGIp+POyQSUVa5jBEq3vkRkY0kjyb3LQgvhU6WGyCcyXqVLWO0Cw0Q6BSdD0kUfVA==",
+      "version": "1.0.30001806",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+      "integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
       "dev": true,
       "funding": [
         {
@@ -7017,9 +7017,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.21.6",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
-      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "version": "5.24.2",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
+      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -8410,9 +8410,9 @@
       }
     },
     "node_modules/fast-xml-parser": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.0.tgz",
-      "integrity": "sha512-SLhnTEqE5QpJHq/6zl9bsmImEP2adv+y6Wy+cJa7nVTRzQh1OZfCe9k29M5xN74LWnu0xa1zrUrq3KnOKl92Fg==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+      "integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
       "funding": [
         {
           "type": "github",
@@ -8421,7 +8421,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@nodable/entities": "^2.2.0",
+        "@nodable/entities": "^3.0.0",
         "fast-xml-builder": "^1.2.0",
         "is-unsafe": "^2.0.0",
         "path-expression-matcher": "^1.6.2",
@@ -16555,9 +16555,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
-      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "version": "4.3.3",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.3.tgz",
+      "integrity": "sha512-gOhV3P7ufE62QDGg1zVaTgCR+EtPv92k2nIhVcVKcLmxT1sUBsQGhnZj175j+MqRt4zLF7ic+sCYjfhxMxj7YQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -17616,20 +17616,6 @@
         "node": ">=10.13.0"
       }
     },
-    "node_modules/webpack/node_modules/enhanced-resolve": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.3"
-      },
-      "engines": {
-        "node": ">=10.13.0"
-      }
-    },
     "node_modules/webpack/node_modules/eslint-scope": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
@@ -18119,9 +18105,9 @@
       }
     },
     "node_modules/yocto-spinner": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.1.tgz",
-      "integrity": "sha512-9cbFWLhbiZp+820O4pkHGNncI7+MrUGzBOjw8NMG+ewsY+aG0DdEXnr19Smxao32YOjLZRMdn1UtaxcrXOYOIg==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-spinner/-/yocto-spinner-1.2.2.tgz",
+      "integrity": "sha512-DODGl1wJjA/s5pnJFKau9lIYHT81lnhob1i3e1TjxZRxEhWRKl74nTbWE6H5KlkViQQTo/Z29YFdxzTZAMY3ng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/src/__tests__/components/InterlinearizerLoader.test.tsx
+++ b/src/__tests__/components/InterlinearizerLoader.test.tsx
@@ -1708,7 +1708,7 @@ describe('InterlinearizerLoader', () => {
       );
     });
 
-    it('leaves the cached activeProject untouched when saveAnalysis reports the project is gone', async () => {
+    it('leaves the cache untouched and the draft dirty when saveAnalysis reports the project is gone', async () => {
       const seeded: MockProject = { ...STUB_ACTIVE_PROJECT, updatedAt: '2026-01-01T00:00:00Z' };
       // saveAnalysis resolves to `undefined` (the project no longer exists), so the loader has no
       // response body to parse and the cache is left as-is.
@@ -1717,19 +1717,27 @@ describe('InterlinearizerLoader', () => {
           ? undefined
           : JSON.stringify(emptyDraft(testProjectId)),
       );
-      await act(async () =>
-        renderLoader({ useWebViewState: makeWebViewState({ activeProject: seeded }) }),
-      );
+      let result: ReturnType<typeof renderLoader> | undefined;
+      await act(async () => {
+        result = renderLoader({ useWebViewState: makeWebViewState({ activeProject: seeded }) });
+      });
+      const updateWebViewDefinition = result?.updateWebViewDefinition;
 
+      // Dirty the draft so the unsaved marker appears, then attempt the doomed Save.
       act(() => {
         capturedInterlinearizerProps?.onSaveAnalysis?.(emptyAnalysis());
       });
+      expect(updateWebViewDefinition).toHaveBeenCalledWith({ title: 'Interlinearizer ●' });
+
+      updateWebViewDefinition?.mockClear();
       await userEvent.click(screen.getByTestId('tab-toolbar-save'));
 
       expect(screen.getByTestId('project-modals')).toHaveAttribute(
         'data-active-project-updated',
         '2026-01-01T00:00:00Z',
       );
+      // Nothing was persisted, so the draft must stay dirty: the marker is never cleared.
+      expect(updateWebViewDefinition).not.toHaveBeenCalledWith({ title: 'Interlinearizer' });
     });
 
     it('marks the draft synced after a successful Save, clearing the tab unsaved marker', async () => {

--- a/src/__tests__/components/InterlinearizerLoader.test.tsx
+++ b/src/__tests__/components/InterlinearizerLoader.test.tsx
@@ -187,6 +187,7 @@ jest.mock('../../components/Interlinearizer', () => {
 type MockProject = {
   id: string;
   createdAt: string;
+  updatedAt?: string;
   sourceProjectId: string;
   analysisLanguages: string[];
   name?: string;
@@ -256,6 +257,7 @@ jest.mock('../../components/modals/ProjectModals', () => ({
         data-default-lang={defaultAnalysisLanguage}
         data-has-unsaved-work={hasUnsavedWork}
         data-active-project-name={activeProject?.name}
+        data-active-project-updated={activeProject?.updatedAt}
       >
         {modal === 'select' && (
           <div data-testid="select-modal">
@@ -1647,6 +1649,86 @@ describe('InterlinearizerLoader', () => {
         JSON.stringify(draftAnalysis),
         // The draft has no custom boundaries, so Save sends "null" to clear any stored ones.
         'null',
+      );
+    });
+
+    it('refreshes the cached activeProject updatedAt from the saveAnalysis response', async () => {
+      // saveAnalysis returns the persisted project carrying the storage-refreshed updatedAt; every
+      // other command keeps its default (the empty-draft load) so the editor still mounts.
+      mockSendCommand.mockImplementation(async (...args) =>
+        args[0] === 'interlinearizer.saveAnalysis'
+          ? JSON.stringify({ ...STUB_ACTIVE_PROJECT, updatedAt: '2026-02-02T00:00:00Z' })
+          : JSON.stringify(emptyDraft(testProjectId)),
+      );
+      await act(async () =>
+        renderLoader({ useWebViewState: makeWebViewState({ activeProject: STUB_ACTIVE_PROJECT }) }),
+      );
+      // The stubbed active project starts with no Modified time cached.
+      expect(screen.getByTestId('project-modals')).not.toHaveAttribute(
+        'data-active-project-updated',
+      );
+
+      // Dirty the draft so the post-save markSynced flips dirty back off, forcing the re-render that
+      // reflects the newly cached updatedAt down to the ProjectModals stub.
+      act(() => {
+        capturedInterlinearizerProps?.onSaveAnalysis?.(emptyAnalysis());
+      });
+      await userEvent.click(screen.getByTestId('tab-toolbar-save'));
+
+      // The stub surfaces the cached activeProject's updatedAt, so the refreshed value proves the
+      // fold reached WebView state.
+      expect(screen.getByTestId('project-modals')).toHaveAttribute(
+        'data-active-project-updated',
+        '2026-02-02T00:00:00Z',
+      );
+    });
+
+    it('leaves the cached activeProject untouched when the saveAnalysis response is malformed', async () => {
+      const seeded: MockProject = { ...STUB_ACTIVE_PROJECT, updatedAt: '2026-01-01T00:00:00Z' };
+      // saveAnalysis returns a payload with no `updatedAt` (e.g. an unexpected shape), so there is
+      // nothing to fold in; other commands keep the default empty-draft load.
+      mockSendCommand.mockImplementation(async (...args) =>
+        args[0] === 'interlinearizer.saveAnalysis'
+          ? JSON.stringify({ notAProject: true })
+          : JSON.stringify(emptyDraft(testProjectId)),
+      );
+      await act(async () =>
+        renderLoader({ useWebViewState: makeWebViewState({ activeProject: seeded }) }),
+      );
+
+      act(() => {
+        capturedInterlinearizerProps?.onSaveAnalysis?.(emptyAnalysis());
+      });
+      await userEvent.click(screen.getByTestId('tab-toolbar-save'));
+
+      // The previously cached Modified time is preserved rather than being cleared.
+      expect(screen.getByTestId('project-modals')).toHaveAttribute(
+        'data-active-project-updated',
+        '2026-01-01T00:00:00Z',
+      );
+    });
+
+    it('leaves the cached activeProject untouched when saveAnalysis reports the project is gone', async () => {
+      const seeded: MockProject = { ...STUB_ACTIVE_PROJECT, updatedAt: '2026-01-01T00:00:00Z' };
+      // saveAnalysis resolves to `undefined` (the project no longer exists), so the loader has no
+      // response body to parse and the cache is left as-is.
+      mockSendCommand.mockImplementation(async (...args) =>
+        args[0] === 'interlinearizer.saveAnalysis'
+          ? undefined
+          : JSON.stringify(emptyDraft(testProjectId)),
+      );
+      await act(async () =>
+        renderLoader({ useWebViewState: makeWebViewState({ activeProject: seeded }) }),
+      );
+
+      act(() => {
+        capturedInterlinearizerProps?.onSaveAnalysis?.(emptyAnalysis());
+      });
+      await userEvent.click(screen.getByTestId('tab-toolbar-save'));
+
+      expect(screen.getByTestId('project-modals')).toHaveAttribute(
+        'data-active-project-updated',
+        '2026-01-01T00:00:00Z',
       );
     });
 

--- a/src/__tests__/components/modals/ProjectMetadataModal.test.tsx
+++ b/src/__tests__/components/modals/ProjectMetadataModal.test.tsx
@@ -154,6 +154,33 @@ describe('ProjectMetadataModal', () => {
     );
   });
 
+  it('threads the server-refreshed updatedAt from the returned project into onProjectSaved', async () => {
+    mockSendCommand.mockResolvedValue(
+      JSON.stringify({ id: 'il-project-uuid', updatedAt: '2026-06-15T09:00:00.000Z' }),
+    );
+    const onProjectSaved = jest.fn();
+    render(<ProjectMetadataModal {...testProps} onProjectSaved={onProjectSaved} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() =>
+      expect(onProjectSaved).toHaveBeenCalledWith(
+        expect.objectContaining({ updatedAt: '2026-06-15T09:00:00.000Z' }),
+      ),
+    );
+  });
+
+  it('omits updatedAt from onProjectSaved when the returned project has none', async () => {
+    // The default mock returns '{}', so no updatedAt is present to thread through.
+    const onProjectSaved = jest.fn();
+    render(<ProjectMetadataModal {...testProps} onProjectSaved={onProjectSaved} />);
+
+    await userEvent.click(screen.getByRole('button', { name: /^save$/i }));
+
+    await waitFor(() => expect(onProjectSaved).toHaveBeenCalled());
+    expect(onProjectSaved.mock.calls[0][0]).not.toHaveProperty('updatedAt');
+  });
+
   it('calls onClose after a successful save', async () => {
     const onClose = jest.fn();
     render(<ProjectMetadataModal {...testProps} onClose={onClose} />);

--- a/src/__tests__/components/modals/ProjectMetadataModal.test.tsx
+++ b/src/__tests__/components/modals/ProjectMetadataModal.test.tsx
@@ -20,6 +20,7 @@ const LOCALIZED: Record<string, string> = {
   '%interlinearizer_modal_metadata_analysis_language_label%': 'Analysis Language',
   '%interlinearizer_modal_metadata_language_placeholder%': 'e.g. en',
   '%interlinearizer_modal_metadata_created_label%': 'Created',
+  '%interlinearizer_modal_metadata_modified_label%': 'Modified',
   '%interlinearizer_modal_metadata_source_label%': 'Source Project',
   '%interlinearizer_modal_metadata_save%': 'Save',
   '%interlinearizer_modal_metadata_close%': 'Close',
@@ -35,6 +36,7 @@ const testProps = {
   sourceProjectId: 'src-project-id',
   analysisLanguages: ['en'],
   createdAt: '2026-01-15T10:30:00.000Z',
+  updatedAt: '2026-01-20T14:00:00.000Z',
   onClose: jest.fn(),
   onProjectSaved: jest.fn(),
   onProjectDeleted: jest.fn(),
@@ -70,6 +72,12 @@ describe('ProjectMetadataModal', () => {
   it('displays the analysis writing system in an editable input', () => {
     render(<ProjectMetadataModal {...testProps} />);
     expect(screen.getByLabelText(/analysis language/i)).toHaveValue('en');
+  });
+
+  it('displays the locale-formatted modified date', () => {
+    render(<ProjectMetadataModal {...testProps} />);
+    const expectedDate = new Date(testProps.updatedAt).toLocaleString();
+    expect(screen.getByText(expectedDate)).toBeInTheDocument();
   });
 
   it('calls onClose when the Close button is clicked', async () => {

--- a/src/__tests__/components/modals/ProjectModals.test.tsx
+++ b/src/__tests__/components/modals/ProjectModals.test.tsx
@@ -6,11 +6,11 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import papi from '@papi/frontend';
 import type { DraftProject } from 'interlinearizer';
-import { makeWebViewState } from '../../test-helpers';
 import type { ModalState } from '../../../components/modals/ProjectModals';
 import ProjectModals from '../../../components/modals/ProjectModals';
-import type { InterlinearProjectSummary } from '../../../types/interlinear-project-summary';
 import { emptyAnalysis } from '../../../types/empty-factories';
+import type { InterlinearProjectSummary } from '../../../types/interlinear-project-summary';
+import { makeWebViewState } from '../../test-helpers';
 
 /** Minimal project summary used in tests. */
 const MOCK_PROJECT: InterlinearProjectSummary = {
@@ -145,17 +145,23 @@ jest.mock('../../../components/modals/CreateProjectModal', () => ({
 jest.mock('../../../components/modals/SaveAsProjectModal', () => ({
   __esModule: true,
   SaveAsProjectModal: ({
+    activeProjectId,
     defaultName,
     onSaveNew,
     onOverwrite,
     onClose,
   }: {
+    activeProjectId?: string;
     defaultName?: string;
     onSaveNew: (name?: string, description?: string) => void;
     onOverwrite: (p: InterlinearProjectSummary) => void;
     onClose: () => void;
   }) => (
-    <div data-testid="saveas-modal" data-default-name={defaultName}>
+    <div
+      data-active-project-id={activeProjectId}
+      data-default-name={defaultName}
+      data-testid="saveas-modal"
+    >
       <button
         type="button"
         data-testid="saveas-new"
@@ -348,6 +354,14 @@ describe('ProjectModals', () => {
       const modal = screen.getByTestId('saveas-modal');
       expect(modal).toBeInTheDocument();
       expect(modal).toHaveAttribute('data-default-name', 'Suggested Name');
+    });
+
+    it('forwards the active project id to the save-as modal so it can badge that overwrite target', () => {
+      render(<ProjectModals {...buildProps({ modal: 'saveAs', activeProject: MOCK_PROJECT })} />);
+      expect(screen.getByTestId('saveas-modal')).toHaveAttribute(
+        'data-active-project-id',
+        'proj-1',
+      );
     });
 
     it('renders the metadata modal when modal is metadata and activeProject is set', () => {

--- a/src/__tests__/components/modals/ProjectModals.test.tsx
+++ b/src/__tests__/components/modals/ProjectModals.test.tsx
@@ -216,6 +216,7 @@ jest.mock('../../../components/modals/ProjectMetadataModal', () => ({
       name?: string;
       description?: string;
       analysisLanguages: string[];
+      updatedAt?: string;
     }) => void;
     onProjectDeleted?: (id: string) => void;
   }) => (
@@ -227,7 +228,11 @@ jest.mock('../../../components/modals/ProjectMetadataModal', () => ({
         type="button"
         data-testid="metadata-save"
         onClick={() => {
-          onProjectSaved?.({ name: 'Updated', analysisLanguages: ['fr'] });
+          onProjectSaved?.({
+            name: 'Updated',
+            analysisLanguages: ['fr'],
+            updatedAt: '2026-06-15T09:00:00Z',
+          });
           onClose();
         }}
       >
@@ -852,6 +857,55 @@ describe('ProjectModals', () => {
       expect(setModal).toHaveBeenCalledWith('none');
     });
 
+    it('makes the server-returned project (with its refreshed updatedAt) the active project on overwrite', async () => {
+      const setActiveProject = jest.fn();
+      const refreshed = { ...MOCK_PROJECT, updatedAt: '2026-06-15T09:00:00Z' };
+      jest
+        .mocked(papi.commands.sendCommand)
+        // saveAnalysis resolves void, then updateProjectMetadata returns the refreshed project.
+        .mockResolvedValueOnce(undefined)
+        .mockResolvedValueOnce(JSON.stringify(refreshed));
+      render(
+        <ProjectModals
+          {...buildProps({
+            modal: 'saveAs',
+            useWebViewState: makeWebViewStateWithActiveProjectSpies({ set: setActiveProject }),
+          })}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('saveas-overwrite'));
+
+      // The refreshed project — not a copy of the pre-save summary — becomes active, so the cached
+      // Modified time reflects the write rather than the stale value.
+      await waitFor(() => expect(setActiveProject).toHaveBeenCalledWith(refreshed));
+    });
+
+    it('falls back to the pre-save summary with the draft config when overwrite metadata returns no project', async () => {
+      const setActiveProject = jest.fn();
+      // Both commands resolve undefined (the blanket default), so the update payload is missing.
+      render(
+        <ProjectModals
+          {...buildProps({
+            modal: 'saveAs',
+            useWebViewState: makeWebViewStateWithActiveProjectSpies({ set: setActiveProject }),
+          })}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('saveas-overwrite'));
+
+      // With no server payload the active project is rebuilt from the target plus the draft's
+      // config (languages carried over, target cleared since the draft has none).
+      await waitFor(() =>
+        expect(setActiveProject).toHaveBeenCalledWith({
+          ...MOCK_PROJECT,
+          analysisLanguages: ['en'],
+          targetProjectId: undefined,
+        }),
+      );
+    });
+
     it('sends the draft segmentation delta when overwriting an existing project', async () => {
       const markSynced = jest.fn();
       render(
@@ -969,11 +1023,14 @@ describe('ProjectModals', () => {
         />,
       );
       await userEvent.click(screen.getByTestId('metadata-save'));
-      // The saved edits ({ name: 'Updated', analysisLanguages: ['fr'] }) merge onto the active project.
+      // The saved edits (name, languages, and the server-refreshed updatedAt) are merged onto the
+      // active project, so a regression that drops the update branch — or the refreshed timestamp —
+      // is caught here.
       expect(setActiveProject).toHaveBeenCalledWith({
         ...MOCK_PROJECT,
         name: 'Updated',
         analysisLanguages: ['fr'],
+        updatedAt: '2026-06-15T09:00:00Z',
       });
       expect(setModal).toHaveBeenCalledWith('none');
     });

--- a/src/__tests__/components/modals/ProjectModals.test.tsx
+++ b/src/__tests__/components/modals/ProjectModals.test.tsx
@@ -515,7 +515,10 @@ describe('ProjectModals', () => {
 
   describe('new (create) flow', () => {
     it('seeds the draft, calls createProject on the backend, and closes', async () => {
-      jest.mocked(papi.commands.sendCommand).mockResolvedValueOnce(JSON.stringify(MOCK_PROJECT));
+      // createProject returns a FULL project (analysis included); only its summary should be cached.
+      jest
+        .mocked(papi.commands.sendCommand)
+        .mockResolvedValueOnce(JSON.stringify(MOCK_FULL_PROJECT));
       const newDraft = jest.fn();
       const setModal = jest.fn();
       const setActiveProject = jest.fn();
@@ -537,6 +540,7 @@ describe('ProjectModals', () => {
       await userEvent.click(screen.getByTestId('create-submit'));
 
       await waitFor(() => expect(setActiveProject).toHaveBeenCalledWith(MOCK_PROJECT));
+      expect(setActiveProject.mock.calls[0][0]).not.toHaveProperty('analysis');
       expect(newDraft).toHaveBeenCalledWith({
         analysisLanguages: ['en'],
         suggestedName: 'New',
@@ -814,6 +818,63 @@ describe('ProjectModals', () => {
       );
     });
 
+    it('caches only the summary of the server-returned project (with its refreshed updatedAt) on Save As New', async () => {
+      const setActiveProject = jest.fn();
+      // saveAnalysis returns a FULL project (analysis included) with a bumped updatedAt.
+      const refreshedFull = {
+        ...MOCK_FULL_PROJECT,
+        updatedAt: '2026-06-15T09:00:00Z',
+      };
+      jest
+        .mocked(papi.commands.sendCommand)
+        // createProject returns the freshly created project, then saveAnalysis returns the same
+        // project with its post-analysis-write updatedAt bumped.
+        .mockResolvedValueOnce(JSON.stringify(MOCK_FULL_PROJECT))
+        .mockResolvedValueOnce(JSON.stringify(refreshedFull));
+      render(
+        <ProjectModals
+          {...buildProps({
+            modal: 'saveAs',
+            useWebViewState: makeWebViewStateWithActiveProjectSpies({ set: setActiveProject }),
+          })}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('saveas-new'));
+
+      // Expected value is `refreshedFull` projected to a summary: the bumped updatedAt is kept, the
+      // analysis dropped.
+      await waitFor(() =>
+        expect(setActiveProject).toHaveBeenCalledWith({
+          ...MOCK_PROJECT,
+          updatedAt: '2026-06-15T09:00:00Z',
+        }),
+      );
+      expect(setActiveProject.mock.calls[0][0]).not.toHaveProperty('analysis');
+    });
+
+    it('caches the created project summary when the Save As New analysis write returns no project', async () => {
+      const setActiveProject = jest.fn();
+      // createProject returns a FULL project; saveAnalysis resolves undefined (blanket default), so
+      // there is no refreshed payload to prefer and the created project's summary is cached.
+      jest
+        .mocked(papi.commands.sendCommand)
+        .mockResolvedValueOnce(JSON.stringify(MOCK_FULL_PROJECT));
+      render(
+        <ProjectModals
+          {...buildProps({
+            modal: 'saveAs',
+            useWebViewState: makeWebViewStateWithActiveProjectSpies({ set: setActiveProject }),
+          })}
+        />,
+      );
+
+      await userEvent.click(screen.getByTestId('saveas-new'));
+
+      await waitFor(() => expect(setActiveProject).toHaveBeenCalledWith(MOCK_PROJECT));
+      expect(setActiveProject.mock.calls[0][0]).not.toHaveProperty('analysis');
+    });
+
     it('notifies and does not mark synced when create returns a non-project shape', async () => {
       jest.mocked(papi.commands.sendCommand).mockResolvedValueOnce(JSON.stringify({ bad: true }));
       const markSynced = jest.fn();
@@ -857,14 +918,15 @@ describe('ProjectModals', () => {
       expect(setModal).toHaveBeenCalledWith('none');
     });
 
-    it('makes the server-returned project (with its refreshed updatedAt) the active project on overwrite', async () => {
+    it('caches only the summary of the server-returned project (with its refreshed updatedAt) on overwrite', async () => {
       const setActiveProject = jest.fn();
-      const refreshed = { ...MOCK_PROJECT, updatedAt: '2026-06-15T09:00:00Z' };
+      // updateProjectMetadata returns a FULL project (analysis included) with a bumped updatedAt.
+      const refreshedFull = { ...MOCK_FULL_PROJECT, updatedAt: '2026-06-15T09:00:00Z' };
       jest
         .mocked(papi.commands.sendCommand)
         // saveAnalysis resolves void, then updateProjectMetadata returns the refreshed project.
         .mockResolvedValueOnce(undefined)
-        .mockResolvedValueOnce(JSON.stringify(refreshed));
+        .mockResolvedValueOnce(JSON.stringify(refreshedFull));
       render(
         <ProjectModals
           {...buildProps({
@@ -876,9 +938,15 @@ describe('ProjectModals', () => {
 
       await userEvent.click(screen.getByTestId('saveas-overwrite'));
 
-      // The refreshed project — not a copy of the pre-save summary — becomes active, so the cached
-      // Modified time reflects the write rather than the stale value.
-      await waitFor(() => expect(setActiveProject).toHaveBeenCalledWith(refreshed));
+      // The bumped updatedAt (not the seeded one) proves the server response was preferred over the
+      // pre-save fallback; projecting it to a summary drops the analysis.
+      await waitFor(() =>
+        expect(setActiveProject).toHaveBeenCalledWith({
+          ...MOCK_PROJECT,
+          updatedAt: '2026-06-15T09:00:00Z',
+        }),
+      );
+      expect(setActiveProject.mock.calls[0][0]).not.toHaveProperty('analysis');
     });
 
     it('falls back to the pre-save summary with the draft config when overwrite metadata returns no project', async () => {

--- a/src/__tests__/components/modals/ProjectModals.test.tsx
+++ b/src/__tests__/components/modals/ProjectModals.test.tsx
@@ -16,6 +16,7 @@ import { emptyAnalysis } from '../../../types/empty-factories';
 const MOCK_PROJECT: InterlinearProjectSummary = {
   id: 'proj-1',
   createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
   sourceProjectId: 'source-proj',
   analysisLanguages: ['en'],
   name: 'My Project',
@@ -24,6 +25,7 @@ const MOCK_PROJECT: InterlinearProjectSummary = {
 const MOCK_PROJECT_2: InterlinearProjectSummary = {
   id: 'proj-2',
   createdAt: '2026-02-01T00:00:00Z',
+  updatedAt: '2026-02-01T00:00:00Z',
   sourceProjectId: 'source-proj',
   analysisLanguages: ['fr'],
   name: 'French Project',

--- a/src/__tests__/components/modals/ProjectSummaryDetails.test.tsx
+++ b/src/__tests__/components/modals/ProjectSummaryDetails.test.tsx
@@ -1,0 +1,45 @@
+/** @file Unit tests for the shared ProjectSummaryDetails row-detail block. */
+/// <reference types="jest" />
+/// <reference types="@testing-library/jest-dom" />
+
+import { render, screen } from '@testing-library/react';
+import { ProjectSummaryDetails } from '../../../components/modals/ProjectSummaryDetails';
+import type { InterlinearProjectSummary } from '../../../types/interlinear-project-summary';
+
+const NAMED_PROJECT: InterlinearProjectSummary = {
+  id: 'proj-uuid',
+  createdAt: '2026-01-15T10:30:00.000Z',
+  updatedAt: '2026-01-15T10:30:00.000Z',
+  sourceProjectId: 'src-proj',
+  analysisLanguages: ['en', 'fr'],
+  name: 'Greek NT',
+};
+
+const LABELS = {
+  activeBadgeLabel: 'Active',
+  modifiedPrefix: 'Modified',
+  unnamedLabel: 'Unnamed',
+};
+
+describe('ProjectSummaryDetails', () => {
+  it('renders the name, joined language tags, and modified date, with no badge when inactive', () => {
+    // No className is passed, exercising the wrapper's empty-class fallback (both modals always pass
+    // one, so this branch is only reachable here).
+    render(<ProjectSummaryDetails {...LABELS} isActive={false} project={NAMED_PROJECT} />);
+
+    expect(screen.getByText('Greek NT')).toBeInTheDocument();
+    expect(screen.getByText('en, fr')).toBeInTheDocument();
+    expect(
+      screen.getByText(`Modified ${new Date(NAMED_PROJECT.updatedAt).toLocaleString()}`),
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+  });
+
+  it('falls back to the unnamed label and shows the active badge when active and unnamed', () => {
+    const unnamed: InterlinearProjectSummary = { ...NAMED_PROJECT, name: undefined };
+    render(<ProjectSummaryDetails {...LABELS} isActive project={unnamed} />);
+
+    expect(screen.getByText('Unnamed')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+});

--- a/src/__tests__/components/modals/SaveAsProjectModal.test.tsx
+++ b/src/__tests__/components/modals/SaveAsProjectModal.test.tsx
@@ -32,6 +32,7 @@ const LOCALIZED: Record<string, string> = {
 const STUB_PROJECT: InterlinearProjectSummary = {
   id: 'proj-uuid',
   createdAt: '2026-01-15T10:30:00.000Z',
+  updatedAt: '2026-01-15T10:30:00.000Z',
   sourceProjectId: 'src-proj',
   analysisLanguages: ['en'],
 };
@@ -39,6 +40,7 @@ const STUB_PROJECT: InterlinearProjectSummary = {
 const STUB_PROJECT_2: InterlinearProjectSummary = {
   id: 'proj-uuid-2',
   createdAt: '2026-02-01T08:00:00.000Z',
+  updatedAt: '2026-02-01T08:00:00.000Z',
   sourceProjectId: 'src-proj',
   analysisLanguages: ['fr'],
   name: 'French glosses',

--- a/src/__tests__/components/modals/SaveAsProjectModal.test.tsx
+++ b/src/__tests__/components/modals/SaveAsProjectModal.test.tsx
@@ -27,6 +27,8 @@ const LOCALIZED: Record<string, string> = {
   '%interlinearizer_modal_saveAs_overwrite_confirm_cancel%': 'Keep project',
   '%interlinearizer_modal_saveAs_cancel%': 'Cancel',
   '%interlinearizer_modal_select_name_unnamed%': 'Unnamed',
+  '%interlinearizer_modal_select_active_badge%': 'Active',
+  '%interlinearizer_modal_select_modified_prefix%': 'Modified',
 };
 
 const STUB_PROJECT: InterlinearProjectSummary = {
@@ -112,6 +114,48 @@ describe('SaveAsProjectModal', () => {
     await waitFor(() =>
       expect(screen.getByText('No existing projects for this source.')).toBeInTheDocument(),
     );
+  });
+
+  it('shows the analysis writing system code and modified date in each overwrite row', async () => {
+    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT]));
+    render(<SaveAsProjectModal {...defaultProps} />);
+
+    await waitFor(() => expect(screen.getByText('Unnamed')).toBeInTheDocument());
+    expect(screen.getByText('en')).toBeInTheDocument();
+    const expectedDate = new Date(STUB_PROJECT.updatedAt).toLocaleString();
+    expect(screen.getByText(`Modified ${expectedDate}`)).toBeInTheDocument();
+  });
+
+  it('badges the overwrite target that matches activeProjectId', async () => {
+    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT, STUB_PROJECT_2]));
+    render(<SaveAsProjectModal {...defaultProps} activeProjectId={STUB_PROJECT_2.id} />);
+
+    await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
+    expect(screen.getByText('Active')).toBeInTheDocument();
+    // The badge sits on the active project's row, not the other one.
+    const frenchRow = screen.getByText('French glosses').closest('li');
+    if (!frenchRow) throw new Error('expected the French glosses row to be present');
+    expect(within(frenchRow).getByText('Active')).toBeInTheDocument();
+  });
+
+  it('shows no active badge when no overwrite target matches activeProjectId', async () => {
+    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT, STUB_PROJECT_2]));
+    render(<SaveAsProjectModal {...defaultProps} activeProjectId="not-in-list" />);
+
+    await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+  });
+
+  it('orders overwrite targets most-recently-modified first', async () => {
+    // STUB_PROJECT is older (Jan 15) than STUB_PROJECT_2 (Feb 1); returned oldest-first so the modal
+    // must reorder to put the newer project on top, matching the Select modal.
+    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT, STUB_PROJECT_2]));
+    render(<SaveAsProjectModal {...defaultProps} />);
+
+    await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
+    const rows = screen.getAllByRole('listitem');
+    expect(within(rows[0]).getByText('French glosses')).toBeInTheDocument();
+    expect(within(rows[1]).getByText('Unnamed')).toBeInTheDocument();
   });
 
   it('shows the inline overwrite confirm and calls onOverwrite with the chosen project', async () => {

--- a/src/__tests__/components/modals/SelectInterlinearProjectModal.test.tsx
+++ b/src/__tests__/components/modals/SelectInterlinearProjectModal.test.tsx
@@ -116,6 +116,21 @@ describe('SelectInterlinearProjectModal', () => {
     expect(rows[1]).toHaveAccessibleName(/unnamed/i);
   });
 
+  it('keeps both projects listed when their modified times are equal', async () => {
+    // Two distinct projects sharing an identical updatedAt exercise the sort comparator's
+    // equal-timestamp branch; both must still render.
+    const sameTimeAsStub: InterlinearProjectSummary = {
+      ...STUB_PROJECT_2,
+      id: 'proj-uuid-3',
+      updatedAt: STUB_PROJECT.updatedAt,
+    };
+    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT, sameTimeAsStub]));
+    render(<SelectInterlinearProjectModal {...defaultProps} />);
+
+    await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
+    expect(screen.getByText('Unnamed')).toBeInTheDocument();
+  });
+
   it('shows the modified date in each row', async () => {
     mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT]));
     render(<SelectInterlinearProjectModal {...defaultProps} />);

--- a/src/__tests__/components/modals/SelectInterlinearProjectModal.test.tsx
+++ b/src/__tests__/components/modals/SelectInterlinearProjectModal.test.tsx
@@ -104,9 +104,11 @@ describe('SelectInterlinearProjectModal', () => {
     await waitFor(() => expect(screen.getByText('en')).toBeInTheDocument());
   });
 
-  it('orders projects most-recently-modified first', async () => {
+  it("orders projects most-recently-modified first and shows each row's modified date", async () => {
     // STUB_PROJECT is older (Jan 15) than STUB_PROJECT_2 (Feb 1); returned oldest-first so the
-    // component must reorder to put the newer project on top.
+    // component must reorder to put the newer project on top. The sort edge cases (equal and
+    // corrupted timestamps) and the date format itself are covered directly in
+    // project-summary-format.test.ts; here we only confirm the modal wires the helpers in.
     mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT, STUB_PROJECT_2]));
     render(<SelectInterlinearProjectModal {...defaultProps} />);
     await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
@@ -114,48 +116,13 @@ describe('SelectInterlinearProjectModal', () => {
     const rows = screen.getAllByRole('button', { name: /french glosses|unnamed/i });
     expect(rows[0]).toHaveAccessibleName(/french glosses/i);
     expect(rows[1]).toHaveAccessibleName(/unnamed/i);
-  });
 
-  it('keeps both projects listed when their modified times are equal', async () => {
-    // Two distinct projects sharing an identical updatedAt exercise the sort comparator's
-    // equal-timestamp branch; both must still render.
-    const sameTimeAsStub: InterlinearProjectSummary = {
-      ...STUB_PROJECT_2,
-      id: 'proj-uuid-3',
-      updatedAt: STUB_PROJECT.updatedAt,
-    };
-    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT, sameTimeAsStub]));
-    render(<SelectInterlinearProjectModal {...defaultProps} />);
-
-    await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
-    expect(screen.getByText('Unnamed')).toBeInTheDocument();
-  });
-
-  it('sorts a project with a corrupted modified time last instead of dropping it', async () => {
-    // updatedAt is a non-date string: it passes the summary type guard (which only checks for a
-    // string) but Date.parse returns NaN, so the comparator must normalize it to 0 and sort it
-    // after the valid project rather than producing an undefined ordering.
-    const corrupted: InterlinearProjectSummary = {
-      ...STUB_PROJECT,
-      id: 'proj-uuid-corrupt',
-      name: 'Corrupted date',
-      updatedAt: 'not-a-real-date',
-    };
-    mockSendCommand.mockResolvedValue(JSON.stringify([corrupted, STUB_PROJECT_2]));
-    render(<SelectInterlinearProjectModal {...defaultProps} />);
-    await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
-
-    const rows = screen.getAllByRole('button', { name: /french glosses|corrupted date/i });
-    expect(rows[0]).toHaveAccessibleName(/french glosses/i);
-    expect(rows[1]).toHaveAccessibleName(/corrupted date/i);
-  });
-
-  it('shows the modified date in each row', async () => {
-    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT]));
-    render(<SelectInterlinearProjectModal {...defaultProps} />);
-
-    const expectedDate = new Date(STUB_PROJECT.updatedAt).toLocaleString();
-    await waitFor(() => expect(screen.getByText(`Modified ${expectedDate}`)).toBeInTheDocument());
+    expect(
+      screen.getByText(`Modified ${new Date(STUB_PROJECT.updatedAt).toLocaleString()}`),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(`Modified ${new Date(STUB_PROJECT_2.updatedAt).toLocaleString()}`),
+    ).toBeInTheDocument();
   });
 
   it('calls onSelect with the project when a project row is clicked', async () => {

--- a/src/__tests__/components/modals/SelectInterlinearProjectModal.test.tsx
+++ b/src/__tests__/components/modals/SelectInterlinearProjectModal.test.tsx
@@ -131,6 +131,25 @@ describe('SelectInterlinearProjectModal', () => {
     expect(screen.getByText('Unnamed')).toBeInTheDocument();
   });
 
+  it('sorts a project with a corrupted modified time last instead of dropping it', async () => {
+    // updatedAt is a non-date string: it passes the summary type guard (which only checks for a
+    // string) but Date.parse returns NaN, so the comparator must normalize it to 0 and sort it
+    // after the valid project rather than producing an undefined ordering.
+    const corrupted: InterlinearProjectSummary = {
+      ...STUB_PROJECT,
+      id: 'proj-uuid-corrupt',
+      name: 'Corrupted date',
+      updatedAt: 'not-a-real-date',
+    };
+    mockSendCommand.mockResolvedValue(JSON.stringify([corrupted, STUB_PROJECT_2]));
+    render(<SelectInterlinearProjectModal {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
+
+    const rows = screen.getAllByRole('button', { name: /french glosses|corrupted date/i });
+    expect(rows[0]).toHaveAccessibleName(/french glosses/i);
+    expect(rows[1]).toHaveAccessibleName(/corrupted date/i);
+  });
+
   it('shows the modified date in each row', async () => {
     mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT]));
     render(<SelectInterlinearProjectModal {...defaultProps} />);

--- a/src/__tests__/components/modals/SelectInterlinearProjectModal.test.tsx
+++ b/src/__tests__/components/modals/SelectInterlinearProjectModal.test.tsx
@@ -19,11 +19,13 @@ const LOCALIZED: Record<string, string> = {
   '%interlinearizer_modal_select_name_unnamed%': 'Unnamed',
   '%interlinearizer_modal_select_info_button_label%': 'Project info',
   '%interlinearizer_modal_select_active_badge%': 'Active',
+  '%interlinearizer_modal_select_modified_prefix%': 'Modified',
 };
 
 const STUB_PROJECT: InterlinearProjectSummary = {
   id: 'proj-uuid',
   createdAt: '2026-01-15T10:30:00.000Z',
+  updatedAt: '2026-01-15T10:30:00.000Z',
   sourceProjectId: 'src-proj',
   analysisLanguages: ['en'],
 };
@@ -31,6 +33,7 @@ const STUB_PROJECT: InterlinearProjectSummary = {
 const STUB_PROJECT_2: InterlinearProjectSummary = {
   id: 'proj-uuid-2',
   createdAt: '2026-02-01T08:00:00.000Z',
+  updatedAt: '2026-02-01T08:00:00.000Z',
   sourceProjectId: 'src-proj',
   analysisLanguages: ['fr'],
   name: 'French glosses',
@@ -99,6 +102,26 @@ describe('SelectInterlinearProjectModal', () => {
     mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT]));
     render(<SelectInterlinearProjectModal {...defaultProps} />);
     await waitFor(() => expect(screen.getByText('en')).toBeInTheDocument());
+  });
+
+  it('orders projects most-recently-modified first', async () => {
+    // STUB_PROJECT is older (Jan 15) than STUB_PROJECT_2 (Feb 1); returned oldest-first so the
+    // component must reorder to put the newer project on top.
+    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT, STUB_PROJECT_2]));
+    render(<SelectInterlinearProjectModal {...defaultProps} />);
+    await waitFor(() => expect(screen.getByText('French glosses')).toBeInTheDocument());
+
+    const rows = screen.getAllByRole('button', { name: /french glosses|unnamed/i });
+    expect(rows[0]).toHaveAccessibleName(/french glosses/i);
+    expect(rows[1]).toHaveAccessibleName(/unnamed/i);
+  });
+
+  it('shows the modified date in each row', async () => {
+    mockSendCommand.mockResolvedValue(JSON.stringify([STUB_PROJECT]));
+    render(<SelectInterlinearProjectModal {...defaultProps} />);
+
+    const expectedDate = new Date(STUB_PROJECT.updatedAt).toLocaleString();
+    await waitFor(() => expect(screen.getByText(`Modified ${expectedDate}`)).toBeInTheDocument());
   });
 
   it('calls onSelect with the project when a project row is clicked', async () => {

--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -903,11 +903,11 @@ describe('main', () => {
       );
     });
 
-    it('delegates to projectStorage.updateAnalysis with the parsed analysis', async () => {
+    it('delegates to projectStorage.updateAnalysis with the parsed analysis and returns undefined when the project is gone', async () => {
       mockUpdateAnalysis.mockResolvedValue(undefined);
       const handler = await getSaveAnalysisHandler();
 
-      await handler('proj-id', JSON.stringify(stubAnalysis));
+      const result = await handler('proj-id', JSON.stringify(stubAnalysis));
 
       // No segmentationJson passed ⇒ the 4th arg is undefined (leave stored boundaries unchanged).
       expect(mockUpdateAnalysis).toHaveBeenCalledWith(
@@ -916,6 +916,19 @@ describe('main', () => {
         stubAnalysis,
         undefined,
       );
+      expect(result).toBeUndefined();
+    });
+
+    it('returns the saved project (carrying the refreshed updatedAt) as JSON when the update succeeds', async () => {
+      const saved = { ...makeStubProject('proj-id'), updatedAt: '2026-06-15T09:00:00Z' };
+      mockUpdateAnalysis.mockResolvedValue(saved);
+      const handler = await getSaveAnalysisHandler();
+
+      const result = await handler('proj-id', JSON.stringify(stubAnalysis));
+
+      // The command serializes the storage layer's refreshed project so the WebView can read the new
+      // Modified time without a second fetch.
+      expect(result).toBe(JSON.stringify(saved));
     });
 
     it('logs the error, sends an error notification, and rethrows when storage throws', async () => {

--- a/src/__tests__/services/projectStorage.test.ts
+++ b/src/__tests__/services/projectStorage.test.ts
@@ -86,6 +86,14 @@ describe('projectStorage', () => {
       expect(project.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T/);
     });
 
+    it('sets updatedAt equal to createdAt at creation', async () => {
+      __mockReadUserData.mockRejectedValue(enoentError());
+
+      const project = await createProject(token, 'src-proj', ['en']);
+
+      expect(project.updatedAt).toBe(project.createdAt);
+    });
+
     it('omits links and targetProjectId for analysis-only projects', async () => {
       __mockReadUserData.mockRejectedValue(enoentError());
 
@@ -243,6 +251,17 @@ describe('projectStorage', () => {
 
   describe('updateProjectMetadata', () => {
     const storedProject = makeStubProject('proj-id');
+    // `updateProjectMetadata` stamps `updatedAt` with `new Date()`; freeze the clock so the exact
+    // stored payload is deterministic and distinct from the fixture's `createdAt`/`updatedAt`.
+    const UPDATE_TIME = '2026-03-01T12:00:00.000Z';
+
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(UPDATE_TIME));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
     it('returns the updated project with the new name and description', async () => {
       __mockReadUserData.mockResolvedValue(JSON.stringify(storedProject));
@@ -260,8 +279,21 @@ describe('projectStorage', () => {
       expect(__mockWriteUserData).toHaveBeenCalledWith(
         token,
         'project:proj-id',
-        JSON.stringify({ ...storedProject, name: 'My Name', description: 'My Desc' }),
+        JSON.stringify({
+          ...storedProject,
+          updatedAt: UPDATE_TIME,
+          name: 'My Name',
+          description: 'My Desc',
+        }),
       );
+    });
+
+    it('refreshes updatedAt to the current time', async () => {
+      __mockReadUserData.mockResolvedValue(JSON.stringify(storedProject));
+
+      const result = await updateProjectMetadata(token, 'proj-id', 'My Name', 'My Desc', ['en']);
+
+      expect(result?.updatedAt).toBe(UPDATE_TIME);
     });
 
     it('removes name and description when called with undefined', async () => {
@@ -419,6 +451,17 @@ describe('projectStorage', () => {
       ...emptyAnalysis(),
       tokenAnalyses: [{ id: 'ta-1', surfaceText: 'In', gloss: { en: 'in' } }],
     };
+    // `updateAnalysis` stamps `updatedAt` with `new Date()`; freeze the clock so the exact stored
+    // payload is deterministic and distinct from the fixture's `createdAt`/`updatedAt`.
+    const UPDATE_TIME = '2026-03-01T12:00:00.000Z';
+
+    beforeEach(() => {
+      jest.useFakeTimers().setSystemTime(new Date(UPDATE_TIME));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
 
     it('returns the updated project with the new analysis', async () => {
       __mockReadUserData.mockResolvedValue(JSON.stringify(storedProject));
@@ -436,8 +479,16 @@ describe('projectStorage', () => {
       expect(__mockWriteUserData).toHaveBeenCalledWith(
         token,
         'project:proj-id',
-        JSON.stringify({ ...storedProject, analysis: newAnalysis }),
+        JSON.stringify({ ...storedProject, analysis: newAnalysis, updatedAt: UPDATE_TIME }),
       );
+    });
+
+    it('refreshes updatedAt to the current time', async () => {
+      __mockReadUserData.mockResolvedValue(JSON.stringify(storedProject));
+
+      const result = await updateAnalysis(token, 'proj-id', newAnalysis);
+
+      expect(result?.updatedAt).toBe(UPDATE_TIME);
     });
 
     it('returns undefined when the project does not exist', async () => {
@@ -465,7 +516,12 @@ describe('projectStorage', () => {
       expect(__mockWriteUserData).toHaveBeenCalledWith(
         token,
         'project:proj-id',
-        JSON.stringify({ ...storedProject, analysis: newAnalysis, segmentation }),
+        JSON.stringify({
+          ...storedProject,
+          analysis: newAnalysis,
+          updatedAt: UPDATE_TIME,
+          segmentation,
+        }),
       );
     });
 

--- a/src/__tests__/test-helpers.ts
+++ b/src/__tests__/test-helpers.ts
@@ -186,6 +186,7 @@ export function makeStubProject(id = 'proj-id'): InterlinearProject {
   return {
     id,
     createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
     sourceProjectId: 'src-project',
     analysisLanguages: ['en'],
     analysis: emptyAnalysis(),

--- a/src/__tests__/utils/project-summary-format.test.ts
+++ b/src/__tests__/utils/project-summary-format.test.ts
@@ -1,0 +1,52 @@
+/** @file Unit tests for utils/project-summary-format.ts (project-list sort + label helpers). */
+/// <reference types="jest" />
+
+import {
+  compareUpdatedAtDescending,
+  formatModified,
+  parseUpdatedAt,
+} from '../../utils/project-summary-format';
+
+describe('parseUpdatedAt', () => {
+  it('parses a valid ISO 8601 timestamp to epoch milliseconds', () => {
+    expect(parseUpdatedAt('2026-01-15T10:30:00.000Z')).toBe(Date.parse('2026-01-15T10:30:00.000Z'));
+  });
+
+  it('normalizes an unparsable timestamp to 0 rather than NaN', () => {
+    // The summary type guard only checks that updatedAt is a string, so a corrupted value must not
+    // leak NaN into the sort comparator (which would make its result undefined).
+    expect(parseUpdatedAt('not-a-real-date')).toBe(0);
+  });
+});
+
+describe('compareUpdatedAtDescending', () => {
+  const older = '2026-01-15T10:30:00.000Z';
+  const newer = '2026-02-01T08:00:00.000Z';
+
+  it('sorts the newer timestamp first (negative when a is newer than b)', () => {
+    expect(compareUpdatedAtDescending(newer, older)).toBeLessThan(0);
+  });
+
+  it('sorts the older timestamp last (positive when a is older than b)', () => {
+    expect(compareUpdatedAtDescending(older, newer)).toBeGreaterThan(0);
+  });
+
+  it('treats equal timestamps as equal (0) so both entries keep their places', () => {
+    expect(compareUpdatedAtDescending(older, older)).toBe(0);
+  });
+
+  it('sorts a corrupted (unparsable) timestamp after a valid one instead of yielding NaN', () => {
+    // Corrupted normalizes to 0, so a valid date always sorts ahead of it.
+    expect(compareUpdatedAtDescending(older, 'not-a-real-date')).toBeLessThan(0);
+    expect(compareUpdatedAtDescending('not-a-real-date', older)).toBeGreaterThan(0);
+  });
+});
+
+describe('formatModified', () => {
+  it('prefixes the locale-formatted timestamp with the given label', () => {
+    const updatedAt = '2026-01-15T10:30:00.000Z';
+    expect(formatModified('Modified', updatedAt)).toBe(
+      `Modified ${new Date(updatedAt).toLocaleString()}`,
+    );
+  });
+});

--- a/src/components/InterlinearizerLoader.tsx
+++ b/src/components/InterlinearizerLoader.tsx
@@ -132,7 +132,7 @@ function InterlinearizerLoaderInner({
    * key; this component reads the value to decide which menu items to show and which analysis
    * language to use.
    */
-  const [activeProject] = useWebViewState<InterlinearProjectSummary | undefined>(
+  const [activeProject, setActiveProject] = useWebViewState<InterlinearProjectSummary | undefined>(
     'activeProject',
     undefined,
   );
@@ -415,7 +415,7 @@ function InterlinearizerLoaderInner({
       return;
     }
     try {
-      await papi.commands.sendCommand(
+      const savedJson = await papi.commands.sendCommand(
         'interlinearizer.saveAnalysis',
         activeProject.id,
         JSON.stringify(snapshot.analysis),
@@ -424,13 +424,25 @@ function InterlinearizerLoaderInner({
         // eslint-disable-next-line no-null/no-null -- "null" is the JSON sentinel that clears boundaries
         JSON.stringify(snapshot.segmentation ?? null),
       );
+      // The command returns the saved project with a refreshed `updatedAt` (bumped by analysis and
+      // by segment-boundary changes alike). Fold it into the cached active project so the picker
+      // sort and the metadata modal's Modified time stay current without a reload. Extract just
+      // `updatedAt` defensively; leave the cache untouched if the payload is unexpectedly shaped.
+      const parsed: unknown = savedJson ? JSON.parse(savedJson) : undefined;
+      const refreshedUpdatedAt =
+        parsed && typeof parsed === 'object' && 'updatedAt' in parsed
+          ? parsed.updatedAt
+          : undefined;
+      if (typeof refreshedUpdatedAt === 'string') {
+        setActiveProject({ ...activeProject, updatedAt: refreshedUpdatedAt });
+      }
       markSynced(snapshot.analysis, snapshot.segmentation);
     } catch (e) {
       logger.error('Interlinearizer: failed to save draft to project', e);
     } finally {
       isSavingRef.current = false;
     }
-  }, [activeProject, getDraftSnapshot, markSynced, setModal]);
+  }, [activeProject, getDraftSnapshot, markSynced, setActiveProject, setModal]);
 
   /**
    * Performs the confirmed wipe for the chosen scope (current book or whole draft) and dismisses

--- a/src/components/InterlinearizerLoader.tsx
+++ b/src/components/InterlinearizerLoader.tsx
@@ -424,19 +424,22 @@ function InterlinearizerLoaderInner({
         // eslint-disable-next-line no-null/no-null -- "null" is the JSON sentinel that clears boundaries
         JSON.stringify(snapshot.segmentation ?? null),
       );
-      // The command returns the saved project with a refreshed `updatedAt` (bumped by analysis and
-      // by segment-boundary changes alike). Fold it into the cached active project so the picker
-      // sort and the metadata modal's Modified time stay current without a reload. Extract just
-      // `updatedAt` defensively; leave the cache untouched if the payload is unexpectedly shaped.
-      const parsed: unknown = savedJson ? JSON.parse(savedJson) : undefined;
-      const refreshedUpdatedAt =
-        parsed && typeof parsed === 'object' && 'updatedAt' in parsed
-          ? parsed.updatedAt
-          : undefined;
-      if (typeof refreshedUpdatedAt === 'string') {
-        setActiveProject({ ...activeProject, updatedAt: refreshedUpdatedAt });
+      // A successful save returns the saved project JSON; `undefined` means the project no longer
+      // exists, so nothing was persisted — leave the draft dirty rather than marking it clean.
+      if (savedJson) {
+        // Fold the response's refreshed `updatedAt` into the cached active project so the picker
+        // sort and the metadata modal's Modified time stay current without a reload; extract it
+        // defensively so an unexpectedly shaped payload leaves the cache untouched.
+        const parsed: unknown = JSON.parse(savedJson);
+        const refreshedUpdatedAt =
+          parsed && typeof parsed === 'object' && 'updatedAt' in parsed
+            ? parsed.updatedAt
+            : undefined;
+        if (typeof refreshedUpdatedAt === 'string') {
+          setActiveProject({ ...activeProject, updatedAt: refreshedUpdatedAt });
+        }
+        markSynced(snapshot.analysis, snapshot.segmentation);
       }
-      markSynced(snapshot.analysis, snapshot.segmentation);
     } catch (e) {
       logger.error('Interlinearizer: failed to save draft to project', e);
     } finally {

--- a/src/components/modals/ProjectMetadataModal.tsx
+++ b/src/components/modals/ProjectMetadataModal.tsx
@@ -54,6 +54,12 @@ type ProjectMetadataModalProps = Readonly<{
     name?: string;
     description?: string;
     analysisLanguages: string[];
+    /**
+     * The server-refreshed modification timestamp, when the backend returned it. Threaded through
+     * so the caller's cached `activeProject` reflects the new Modified time immediately rather than
+     * keeping the pre-save value.
+     */
+    updatedAt?: string;
   }) => void;
   /** Optional callback invoked with the deleted project ID after deletion. */
   onProjectDeleted?: (deletedProjectId: string) => void;
@@ -126,10 +132,19 @@ export function ProjectMetadataModal({
             targetProjectId,
           );
           if (!updatedProjectJson) return;
+          // The command returns the saved project JSON with a refreshed `updatedAt`; parse it out so
+          // the caller's cached copy shows the new Modified time. Falls back to omitting it if the
+          // payload is unexpectedly shaped rather than surfacing a parse error to the user.
+          const parsed: unknown = JSON.parse(updatedProjectJson);
+          const refreshedUpdatedAt =
+            parsed && typeof parsed === 'object' && 'updatedAt' in parsed
+              ? parsed.updatedAt
+              : undefined;
           onProjectSaved?.({
             name: newName,
             description: newDescription,
             analysisLanguages: parsedLanguages,
+            ...(typeof refreshedUpdatedAt === 'string' && { updatedAt: refreshedUpdatedAt }),
           });
           onClose();
         } catch (e) {

--- a/src/components/modals/ProjectMetadataModal.tsx
+++ b/src/components/modals/ProjectMetadataModal.tsx
@@ -18,6 +18,7 @@ const PROJECT_METADATA_MODAL_STRING_KEYS: `%${string}%`[] = [
   '%interlinearizer_modal_metadata_analysis_language_label%',
   '%interlinearizer_modal_metadata_language_placeholder%',
   '%interlinearizer_modal_metadata_created_label%',
+  '%interlinearizer_modal_metadata_modified_label%',
   '%interlinearizer_modal_metadata_source_label%',
   '%interlinearizer_modal_metadata_save%',
   '%interlinearizer_modal_metadata_close%',
@@ -44,6 +45,8 @@ type ProjectMetadataModalProps = Readonly<{
   analysisLanguages: string[];
   /** ISO 8601 creation timestamp. */
   createdAt: string;
+  /** ISO 8601 timestamp of the most recent modification. */
+  updatedAt: string;
   /** Callback invoked when the modal should be dismissed without saving. */
   onClose: () => void;
   /** Optional callback invoked with updated metadata after a successful save. */
@@ -72,6 +75,7 @@ export function ProjectMetadataModal({
   targetProjectId,
   analysisLanguages,
   createdAt,
+  updatedAt,
   onClose,
   onProjectSaved,
   onProjectDeleted,
@@ -88,6 +92,7 @@ export function ProjectMetadataModal({
   const { isSubmitting, runGuarded } = useSubmitGuard();
 
   const formattedDate = useMemo(() => new Date(createdAt).toLocaleString(), [createdAt]);
+  const formattedModifiedDate = useMemo(() => new Date(updatedAt).toLocaleString(), [updatedAt]);
 
   /**
    * Parsed analysis-language tags from the comma-separated field. Computed once and reused by both
@@ -228,6 +233,10 @@ export function ProjectMetadataModal({
         <MetadataRow
           label={localizedStrings['%interlinearizer_modal_metadata_created_label%']}
           value={formattedDate}
+        />
+        <MetadataRow
+          label={localizedStrings['%interlinearizer_modal_metadata_modified_label%']}
+          value={formattedModifiedDate}
         />
         <MetadataRow
           label={localizedStrings['%interlinearizer_modal_metadata_source_label%']}

--- a/src/components/modals/ProjectMetadataModal.tsx
+++ b/src/components/modals/ProjectMetadataModal.tsx
@@ -54,11 +54,6 @@ type ProjectMetadataModalProps = Readonly<{
     name?: string;
     description?: string;
     analysisLanguages: string[];
-    /**
-     * The server-refreshed modification timestamp, when the backend returned it. Threaded through
-     * so the caller's cached `activeProject` reflects the new Modified time immediately rather than
-     * keeping the pre-save value.
-     */
     updatedAt?: string;
   }) => void;
   /** Optional callback invoked with the deleted project ID after deletion. */
@@ -132,19 +127,19 @@ export function ProjectMetadataModal({
             targetProjectId,
           );
           if (!updatedProjectJson) return;
-          // The command returns the saved project JSON with a refreshed `updatedAt`; parse it out so
-          // the caller's cached copy shows the new Modified time. Falls back to omitting it if the
-          // payload is unexpectedly shaped rather than surfacing a parse error to the user.
+          // Parse the refreshed `updatedAt` out of the returned project so the caller's cached copy
+          // shows the new Modified time; omit it defensively if the payload is unexpectedly shaped.
           const parsed: unknown = JSON.parse(updatedProjectJson);
-          const refreshedUpdatedAt =
+          const rawUpdatedAt =
             parsed && typeof parsed === 'object' && 'updatedAt' in parsed
               ? parsed.updatedAt
               : undefined;
+          const refreshedUpdatedAt = typeof rawUpdatedAt === 'string' ? rawUpdatedAt : undefined;
           onProjectSaved?.({
             name: newName,
             description: newDescription,
             analysisLanguages: parsedLanguages,
-            ...(typeof refreshedUpdatedAt === 'string' && { updatedAt: refreshedUpdatedAt }),
+            ...(refreshedUpdatedAt !== undefined && { updatedAt: refreshedUpdatedAt }),
           });
           onClose();
         } catch (e) {

--- a/src/components/modals/ProjectModals.tsx
+++ b/src/components/modals/ProjectModals.tsx
@@ -550,6 +550,7 @@ export default function ProjectModals({
           targetProjectId={resolvedMetadataProject.targetProjectId}
           analysisLanguages={resolvedMetadataProject.analysisLanguages}
           createdAt={resolvedMetadataProject.createdAt}
+          updatedAt={resolvedMetadataProject.updatedAt}
           onClose={handleMetadataClose}
           onProjectSaved={handleMetadataProjectSaved}
           onProjectDeleted={handleMetadataProjectDeleted}

--- a/src/components/modals/ProjectModals.tsx
+++ b/src/components/modals/ProjectModals.tsx
@@ -4,10 +4,8 @@ import type { DraftProject, SegmentationDelta, TextAnalysis } from 'interlineari
 import { useCallback, useState } from 'react';
 import type { NewDraftConfig, OpenableProject } from '../../hooks/useDraftProject';
 import useSubmitGuard from '../../hooks/useSubmitGuard';
-import {
-  toProjectSummary,
-  type InterlinearProjectSummary,
-} from '../../types/interlinear-project-summary';
+import { toProjectSummary } from '../../types/interlinear-project-summary';
+import type { InterlinearProjectSummary } from '../../types/interlinear-project-summary';
 import {
   isInterlinearProjectSummary,
   isSegmentationDelta,
@@ -555,6 +553,7 @@ export default function ProjectModals({
       {modal === 'saveAs' && (
         <SaveAsProjectModal
           sourceProjectId={projectId}
+          activeProjectId={activeProject?.id}
           defaultName={draftSnapshot?.suggestedName}
           defaultDescription={draftSnapshot?.suggestedDescription}
           onSaveNew={handleSaveAsNew}

--- a/src/components/modals/ProjectModals.tsx
+++ b/src/components/modals/ProjectModals.tsx
@@ -152,12 +152,18 @@ export default function ProjectModals({
 
   /**
    * Called when the metadata modal saves changes. Updates `activeProject` state when the edited
-   * project is the currently active one.
+   * project is the currently active one, carrying through the server-refreshed `updatedAt` so the
+   * cached Modified time (shown in the picker and on modal reopen) stays current.
    *
-   * @param updated - The updated name, description, and analysisLanguages.
+   * @param updated - The updated name, description, analysisLanguages, and refreshed `updatedAt`.
    */
   const handleMetadataProjectSaved = useCallback(
-    (updated: { name?: string; description?: string; analysisLanguages: string[] }) => {
+    (updated: {
+      name?: string;
+      description?: string;
+      analysisLanguages: string[];
+      updatedAt?: string;
+    }) => {
       if (activeProject && resolvedMetadataProject?.id === activeProject.id) {
         setActiveProject({ ...activeProject, ...updated });
       }
@@ -448,7 +454,7 @@ export default function ProjectModals({
         // metadata stays consistent with the glosses just written (mirroring how Save As → New
         // carries the draft's config into the created project). The project's name and description
         // are intentionally preserved — overwriting keeps the target's identity.
-        await papi.commands.sendCommand(
+        const updatedJson = await papi.commands.sendCommand(
           'interlinearizer.updateProjectMetadata',
           project.id,
           project.name,
@@ -456,13 +462,21 @@ export default function ProjectModals({
           snapshot.analysisLanguages,
           snapshot.targetProjectId,
         );
-        setActiveProject({
-          ...project,
-          analysisLanguages: snapshot.analysisLanguages,
-          // Assign explicitly (rather than a conditional spread) so a target binding on the
-          // overwritten project is cleared when the draft has none, matching what was persisted.
-          targetProjectId: snapshot.targetProjectId,
-        });
+        // Prefer the server-returned project (it carries the refreshed `updatedAt`) as the new
+        // active project; fall back to the pre-save object with the draft's config if the payload is
+        // missing or malformed so the Save still completes.
+        const parsedUpdated: unknown = updatedJson ? JSON.parse(updatedJson) : undefined;
+        setActiveProject(
+          isInterlinearProjectSummary(parsedUpdated)
+            ? parsedUpdated
+            : {
+                ...project,
+                analysisLanguages: snapshot.analysisLanguages,
+                // Assign explicitly (rather than a conditional spread) so a target binding on the
+                // overwritten project is cleared when the draft has none, matching what was persisted.
+                targetProjectId: snapshot.targetProjectId,
+              },
+        );
         markSynced(snapshot.analysis, snapshot.segmentation);
         setModal('none');
       } catch (e) {

--- a/src/components/modals/ProjectModals.tsx
+++ b/src/components/modals/ProjectModals.tsx
@@ -4,7 +4,10 @@ import type { DraftProject, SegmentationDelta, TextAnalysis } from 'interlineari
 import { useCallback, useState } from 'react';
 import type { NewDraftConfig, OpenableProject } from '../../hooks/useDraftProject';
 import useSubmitGuard from '../../hooks/useSubmitGuard';
-import type { InterlinearProjectSummary } from '../../types/interlinear-project-summary';
+import {
+  toProjectSummary,
+  type InterlinearProjectSummary,
+} from '../../types/interlinear-project-summary';
 import {
   isInterlinearProjectSummary,
   isSegmentationDelta,
@@ -273,7 +276,9 @@ export default function ProjectModals({
         );
         const parsed: unknown = JSON.parse(createdJson);
         if (isInterlinearProjectSummary(parsed)) {
-          created = parsed;
+          // `createProject` returns a full `InterlinearProject`; project it so its `analysis` is not
+          // cached into WebView state (see `toProjectSummary`).
+          created = toProjectSummary(parsed);
         } else {
           await papi.notifications
             .send({ message: '%interlinearizer_error_create_project_failed%', severity: 'error' })
@@ -405,7 +410,7 @@ export default function ProjectModals({
           return;
         }
 
-        await papi.commands.sendCommand(
+        const savedJson = await papi.commands.sendCommand(
           'interlinearizer.saveAnalysis',
           created.id,
           JSON.stringify(snapshot.analysis),
@@ -414,7 +419,12 @@ export default function ProjectModals({
           // eslint-disable-next-line no-null/no-null -- "null" is the JSON sentinel that clears boundaries
           JSON.stringify(snapshot.segmentation ?? null),
         );
-        setActiveProject(created);
+        // `saveAnalysis` bumps `updatedAt` past the creation time it was born with, so prefer the
+        // project it returns; fall back to the freshly created object if the payload is malformed.
+        const parsedSaved: unknown = savedJson ? JSON.parse(savedJson) : undefined;
+        setActiveProject(
+          toProjectSummary(isInterlinearProjectSummary(parsedSaved) ? parsedSaved : created),
+        );
         markSynced(snapshot.analysis, snapshot.segmentation);
         setModal('none');
       } catch (e) {
@@ -468,7 +478,7 @@ export default function ProjectModals({
         const parsedUpdated: unknown = updatedJson ? JSON.parse(updatedJson) : undefined;
         setActiveProject(
           isInterlinearProjectSummary(parsedUpdated)
-            ? parsedUpdated
+            ? toProjectSummary(parsedUpdated)
             : {
                 ...project,
                 analysisLanguages: snapshot.analysisLanguages,

--- a/src/components/modals/ProjectModals.tsx
+++ b/src/components/modals/ProjectModals.tsx
@@ -276,8 +276,6 @@ export default function ProjectModals({
         );
         const parsed: unknown = JSON.parse(createdJson);
         if (isInterlinearProjectSummary(parsed)) {
-          // `createProject` returns a full `InterlinearProject`; project it so its `analysis` is not
-          // cached into WebView state (see `toProjectSummary`).
           created = toProjectSummary(parsed);
         } else {
           await papi.notifications

--- a/src/components/modals/ProjectSummaryDetails.tsx
+++ b/src/components/modals/ProjectSummaryDetails.tsx
@@ -1,0 +1,58 @@
+import type { InterlinearProjectSummary } from '../../types/interlinear-project-summary';
+import { formatModified } from '../../utils/project-summary-format';
+
+/**
+ * The two-line detail block shown for a project in a list: the name (with an optional "active"
+ * badge and the right-aligned analysis-language tags) on the first line, and the localized modified
+ * date on the second. Shared by {@link SelectInterlinearProjectModal} (inside its clickable row
+ * button) and {@link SaveAsProjectModal} (inside each overwrite target) so both lists present the
+ * same detail; it is purely presentational and owns no chrome (border, padding, click behavior),
+ * which the parent supplies around it.
+ *
+ * @param props - Component props.
+ * @param props.activeBadgeLabel - Localized text of the active badge.
+ * @param props.className - Extra classes appended to the wrapper (e.g. `tw:flex-1` so the block
+ *   grows to fill the row).
+ * @param props.isActive - Whether this project is the currently active Save target; when `true` the
+ *   active badge is shown beside the name.
+ * @param props.modifiedPrefix - Localized `"Modified"` label preceding the formatted date.
+ * @param props.project - The project summary to describe.
+ * @param props.unnamedLabel - Localized fallback label rendered when the project has no name.
+ * @returns The detail block.
+ */
+export function ProjectSummaryDetails({
+  activeBadgeLabel,
+  className,
+  isActive,
+  modifiedPrefix,
+  project,
+  unnamedLabel,
+}: Readonly<{
+  activeBadgeLabel: string;
+  className?: string;
+  isActive: boolean;
+  modifiedPrefix: string;
+  project: InterlinearProjectSummary;
+  unnamedLabel: string;
+}>) {
+  return (
+    <span className={`tw:flex tw:flex-col tw:gap-0.5 tw:min-w-0 ${className ?? ''}`}>
+      <span className="tw:flex tw:items-center tw:gap-2 tw:min-w-0">
+        <span className="tw:font-medium tw:text-foreground tw:truncate">
+          {project.name ?? unnamedLabel}
+        </span>
+        {isActive && (
+          <span className="tw:shrink-0 tw:rounded tw:bg-primary tw:px-1.5 tw:py-0.5 tw:text-xs tw:font-medium tw:text-primary-foreground">
+            {activeBadgeLabel}
+          </span>
+        )}
+        <span className="tw:font-mono tw:text-xs tw:text-muted-foreground tw:shrink-0 tw:ms-auto">
+          {project.analysisLanguages.join(', ')}
+        </span>
+      </span>
+      <span className="tw:text-xs tw:text-muted-foreground">
+        {formatModified(modifiedPrefix, project.updatedAt)}
+      </span>
+    </span>
+  );
+}

--- a/src/components/modals/SaveAsProjectModal.tsx
+++ b/src/components/modals/SaveAsProjectModal.tsx
@@ -2,10 +2,12 @@ import papi, { logger } from '@papi/frontend';
 import { useLocalizedStrings } from '@papi/frontend/react';
 import { Button } from 'platform-bible-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import useSubmitGuard from '../../hooks/useSubmitGuard';
 import type { InterlinearProjectSummary } from '../../types/interlinear-project-summary';
 import { isInterlinearProjectSummary } from '../../types/type-guards';
-import useSubmitGuard from '../../hooks/useSubmitGuard';
+import { compareUpdatedAtDescending } from '../../utils/project-summary-format';
 import { ModalShell } from './ModalShell';
+import { ProjectSummaryDetails } from './ProjectSummaryDetails';
 
 /** Localized string keys used by {@link SaveAsProjectModal}. */
 const SAVE_AS_MODAL_STRING_KEYS: `%${string}%`[] = [
@@ -24,6 +26,8 @@ const SAVE_AS_MODAL_STRING_KEYS: `%${string}%`[] = [
   '%interlinearizer_modal_saveAs_overwrite_confirm_cancel%',
   '%interlinearizer_modal_saveAs_cancel%',
   '%interlinearizer_modal_select_name_unnamed%',
+  '%interlinearizer_modal_select_active_badge%',
+  '%interlinearizer_modal_select_modified_prefix%',
 ];
 
 /**
@@ -35,6 +39,9 @@ const SAVE_AS_MODAL_STRING_KEYS: `%${string}%`[] = [
  * @param props - Component props
  * @param props.sourceProjectId - Source project whose existing interlinear projects to list as
  *   overwrite targets.
+ * @param props.activeProjectId - ID of the project currently open as the active Save target, if
+ *   any; the matching overwrite target is badged so the user can tell which project the draft is
+ *   currently working against.
  * @param props.defaultName - Name prefilled into the new-project field (the draft's suggested
  *   name).
  * @param props.defaultDescription - Description prefilled into the new-project field.
@@ -47,6 +54,7 @@ const SAVE_AS_MODAL_STRING_KEYS: `%${string}%`[] = [
  */
 export function SaveAsProjectModal({
   sourceProjectId,
+  activeProjectId,
   defaultName,
   defaultDescription,
   onSaveNew,
@@ -54,6 +62,7 @@ export function SaveAsProjectModal({
   onClose,
 }: Readonly<{
   sourceProjectId: string;
+  activeProjectId?: string;
   defaultName?: string;
   defaultDescription?: string;
   onSaveNew: (name?: string, description?: string) => void | Promise<void>;
@@ -100,7 +109,11 @@ export function SaveAsProjectModal({
       /* v8 ignore next 2 -- backend always returns a JSON array; defensive guard */
       if (!Array.isArray(parsed))
         throw new TypeError('getProjectsForSource did not return an array');
-      setProjects(parsed.filter(isInterlinearProjectSummary));
+      const valid = parsed.filter(isInterlinearProjectSummary);
+      // Most-recently-modified first, matching the Select modal so the overwrite target the user is
+      // likeliest to want sits at the top and the modified date distinguishes unnamed projects.
+      valid.sort((a, b) => compareUpdatedAtDescending(a.updatedAt, b.updatedAt));
+      setProjects(valid);
     } catch (e) {
       // Ignore a failure from a load that a newer one has superseded (mirrors the success-path stale
       // guard above) so a stale rejection cannot fire a spurious error notification.
@@ -203,13 +216,24 @@ export function SaveAsProjectModal({
               <li key={project.id} className="tw:flex tw:flex-col tw:gap-2">
                 <div className="tw:flex tw:items-center tw:gap-2">
                   <span
-                    className={`tw:flex-1 tw:flex tw:items-center tw:gap-2 tw:rounded tw:border tw:px-3 tw:py-2 tw:text-sm tw:min-w-0 ${
+                    className={`tw:flex-1 tw:flex tw:rounded tw:border tw:px-3 tw:py-2 tw:text-sm tw:min-w-0 ${
                       isConfirming
                         ? 'tw:border-destructive tw:bg-destructive/10'
                         : 'tw:border-border tw:bg-muted/40'
                     }`}
                   >
-                    <span className="tw:font-medium tw:truncate">{projectName}</span>
+                    <ProjectSummaryDetails
+                      activeBadgeLabel={
+                        localizedStrings['%interlinearizer_modal_select_active_badge%']
+                      }
+                      className="tw:flex-1"
+                      isActive={project.id === activeProjectId}
+                      modifiedPrefix={
+                        localizedStrings['%interlinearizer_modal_select_modified_prefix%']
+                      }
+                      project={project}
+                      unnamedLabel={localizedStrings['%interlinearizer_modal_select_name_unnamed%']}
+                    />
                   </span>
                   <Button
                     variant="secondary"

--- a/src/components/modals/SelectInterlinearProjectModal.tsx
+++ b/src/components/modals/SelectInterlinearProjectModal.tsx
@@ -20,6 +20,20 @@ const SELECT_INTERLINEAR_PROJECT_STRING_KEYS: `%${string}%`[] = [
 ];
 
 /**
+ * Parses an ISO 8601 timestamp to epoch milliseconds, treating an unparseable string as `0`. The
+ * summary type guard only checks that `updatedAt` is a string, so a corrupted value could otherwise
+ * yield `NaN` and make the sort comparator's result undefined; normalizing to `0` keeps ordering
+ * deterministic (corrupted entries sort last).
+ *
+ * @param value - The timestamp string to parse.
+ * @returns The parsed epoch milliseconds, or `0` when `value` is not a valid date.
+ */
+function parseUpdatedAt(value: string): number {
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? 0 : time;
+}
+
+/**
  * Compares two ISO 8601 timestamps for a descending (newest-first) sort by their parsed epoch
  * milliseconds, so ordering is locale-independent (unlike `localeCompare`, whose result can vary by
  * collator).
@@ -30,7 +44,7 @@ const SELECT_INTERLINEAR_PROJECT_STRING_KEYS: `%${string}%`[] = [
  *   when the two timestamps are equal.
  */
 function compareUpdatedAtDescending(a: string, b: string): number {
-  return Date.parse(b) - Date.parse(a);
+  return parseUpdatedAt(b) - parseUpdatedAt(a);
 }
 
 /**
@@ -119,10 +133,8 @@ export function SelectInterlinearProjectModal({
         );
       // Most-recently-modified first so the project the user is likeliest to reopen sits at the top,
       // and the modified date distinguishes otherwise-identical unnamed projects.
-      const sorted = [...valid].sort((a, b) =>
-        compareUpdatedAtDescending(a.updatedAt, b.updatedAt),
-      );
-      setProjects(sorted);
+      valid.sort((a, b) => compareUpdatedAtDescending(a.updatedAt, b.updatedAt));
+      setProjects(valid);
     } catch (e) {
       logger.error('Interlinearizer: failed to load projects for source', e);
       await papi.notifications

--- a/src/components/modals/SelectInterlinearProjectModal.tsx
+++ b/src/components/modals/SelectInterlinearProjectModal.tsx
@@ -20,6 +20,20 @@ const SELECT_INTERLINEAR_PROJECT_STRING_KEYS: `%${string}%`[] = [
 ];
 
 /**
+ * Compares two ISO 8601 timestamps for a descending (newest-first) sort by their parsed epoch
+ * milliseconds, so ordering is locale-independent (unlike `localeCompare`, whose result can vary by
+ * collator).
+ *
+ * @param a - The first ISO 8601 timestamp.
+ * @param b - The second ISO 8601 timestamp.
+ * @returns A negative number when `a` is newer than `b` (sorts first), positive when older, `0`
+ *   when the two timestamps are equal.
+ */
+function compareUpdatedAtDescending(a: string, b: string): number {
+  return Date.parse(b) - Date.parse(a);
+}
+
+/**
  * Formats the modified-date subline for a project row, e.g. `"Modified Jan 1, 2026, 12:00 PM"`. The
  * prefix is a localized label; the timestamp is rendered in the user's locale via
  * `toLocaleString`.
@@ -105,8 +119,11 @@ export function SelectInterlinearProjectModal({
         );
       // Most-recently-modified first so the project the user is likeliest to reopen sits at the top
       // and the modified date reads as a meaningful distinguisher between otherwise-identical
-      // unnamed projects.
-      const sorted = [...valid].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      // unnamed projects. Ordered by parsed epoch time so it stays locale-independent (no
+      // `localeCompare`/collator involvement).
+      const sorted = [...valid].sort((a, b) =>
+        compareUpdatedAtDescending(a.updatedAt, b.updatedAt),
+      );
       setProjects(sorted);
     } catch (e) {
       logger.error('Interlinearizer: failed to load projects for source', e);

--- a/src/components/modals/SelectInterlinearProjectModal.tsx
+++ b/src/components/modals/SelectInterlinearProjectModal.tsx
@@ -117,10 +117,8 @@ export function SelectInterlinearProjectModal({
           'Interlinearizer: skipped malformed project entries',
           parsed.length - valid.length,
         );
-      // Most-recently-modified first so the project the user is likeliest to reopen sits at the top
-      // and the modified date reads as a meaningful distinguisher between otherwise-identical
-      // unnamed projects. Ordered by parsed epoch time so it stays locale-independent (no
-      // `localeCompare`/collator involvement).
+      // Most-recently-modified first so the project the user is likeliest to reopen sits at the top,
+      // and the modified date distinguishes otherwise-identical unnamed projects.
       const sorted = [...valid].sort((a, b) =>
         compareUpdatedAtDescending(a.updatedAt, b.updatedAt),
       );

--- a/src/components/modals/SelectInterlinearProjectModal.tsx
+++ b/src/components/modals/SelectInterlinearProjectModal.tsx
@@ -5,7 +5,9 @@ import { Button } from 'platform-bible-react';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { InterlinearProjectSummary } from '../../types/interlinear-project-summary';
 import { isInterlinearProjectSummary } from '../../types/type-guards';
+import { compareUpdatedAtDescending } from '../../utils/project-summary-format';
 import { ModalShell } from './ModalShell';
+import { ProjectSummaryDetails } from './ProjectSummaryDetails';
 
 /** Localized string keys used by {@link SelectInterlinearProjectModal}. */
 const SELECT_INTERLINEAR_PROJECT_STRING_KEYS: `%${string}%`[] = [
@@ -18,47 +20,6 @@ const SELECT_INTERLINEAR_PROJECT_STRING_KEYS: `%${string}%`[] = [
   '%interlinearizer_modal_select_active_badge%',
   '%interlinearizer_modal_select_modified_prefix%',
 ];
-
-/**
- * Parses an ISO 8601 timestamp to epoch milliseconds, treating an unparseable string as `0`. The
- * summary type guard only checks that `updatedAt` is a string, so a corrupted value could otherwise
- * yield `NaN` and make the sort comparator's result undefined; normalizing to `0` keeps ordering
- * deterministic (corrupted entries sort last).
- *
- * @param value - The timestamp string to parse.
- * @returns The parsed epoch milliseconds, or `0` when `value` is not a valid date.
- */
-function parseUpdatedAt(value: string): number {
-  const time = Date.parse(value);
-  return Number.isNaN(time) ? 0 : time;
-}
-
-/**
- * Compares two ISO 8601 timestamps for a descending (newest-first) sort by their parsed epoch
- * milliseconds, so ordering is locale-independent (unlike `localeCompare`, whose result can vary by
- * collator).
- *
- * @param a - The first ISO 8601 timestamp.
- * @param b - The second ISO 8601 timestamp.
- * @returns A negative number when `a` is newer than `b` (sorts first), positive when older, `0`
- *   when the two timestamps are equal.
- */
-function compareUpdatedAtDescending(a: string, b: string): number {
-  return parseUpdatedAt(b) - parseUpdatedAt(a);
-}
-
-/**
- * Formats the modified-date subline for a project row, e.g. `"Modified Jan 1, 2026, 12:00 PM"`. The
- * prefix is a localized label; the timestamp is rendered in the user's locale via
- * `toLocaleString`.
- *
- * @param prefix - Localized `"Modified"` label to precede the date.
- * @param updatedAt - ISO 8601 modification timestamp.
- * @returns The prefix followed by the locale-formatted timestamp.
- */
-function formatModified(prefix: string, updatedAt: string): string {
-  return `${prefix} ${new Date(updatedAt).toLocaleString()}`;
-}
 
 /**
  * Modal that lists all existing interlinearizer projects for a source project and lets the user
@@ -171,33 +132,25 @@ export function SelectInterlinearProjectModal({
                 <button
                   type="button"
                   aria-current={isActive ? 'true' : undefined}
-                  className={`tw:flex-1 tw:flex tw:flex-col tw:gap-0.5 tw:rounded tw:border tw:px-3 tw:py-2 tw:text-left tw:text-sm tw:transition-colors tw:min-w-0 ${
+                  className={`tw:flex-1 tw:flex tw:rounded tw:border tw:px-3 tw:py-2 tw:text-left tw:text-sm tw:transition-colors tw:min-w-0 ${
                     isActive
                       ? 'tw:border-primary tw:bg-primary/10 tw:hover:bg-primary/20'
                       : 'tw:border-border tw:bg-muted/40 tw:hover:bg-muted/70'
                   }`}
                   onClick={() => onSelect(project)}
                 >
-                  <span className="tw:flex tw:items-center tw:gap-2 tw:min-w-0">
-                    <span className="tw:font-medium tw:text-foreground tw:truncate">
-                      {project.name ??
-                        localizedStrings['%interlinearizer_modal_select_name_unnamed%']}
-                    </span>
-                    {isActive && (
-                      <span className="tw:shrink-0 tw:rounded tw:bg-primary tw:px-1.5 tw:py-0.5 tw:text-xs tw:font-medium tw:text-primary-foreground">
-                        {localizedStrings['%interlinearizer_modal_select_active_badge%']}
-                      </span>
-                    )}
-                    <span className="tw:font-mono tw:text-xs tw:text-muted-foreground tw:shrink-0 tw:ms-auto">
-                      {project.analysisLanguages.join(', ')}
-                    </span>
-                  </span>
-                  <span className="tw:text-xs tw:text-muted-foreground">
-                    {formatModified(
-                      localizedStrings['%interlinearizer_modal_select_modified_prefix%'],
-                      project.updatedAt,
-                    )}
-                  </span>
+                  <ProjectSummaryDetails
+                    activeBadgeLabel={
+                      localizedStrings['%interlinearizer_modal_select_active_badge%']
+                    }
+                    className="tw:flex-1"
+                    isActive={isActive}
+                    modifiedPrefix={
+                      localizedStrings['%interlinearizer_modal_select_modified_prefix%']
+                    }
+                    project={project}
+                    unnamedLabel={localizedStrings['%interlinearizer_modal_select_name_unnamed%']}
+                  />
                 </button>
                 <Button
                   variant="ghost"

--- a/src/components/modals/SelectInterlinearProjectModal.tsx
+++ b/src/components/modals/SelectInterlinearProjectModal.tsx
@@ -16,7 +16,21 @@ const SELECT_INTERLINEAR_PROJECT_STRING_KEYS: `%${string}%`[] = [
   '%interlinearizer_modal_select_name_unnamed%',
   '%interlinearizer_modal_select_info_button_label%',
   '%interlinearizer_modal_select_active_badge%',
+  '%interlinearizer_modal_select_modified_prefix%',
 ];
+
+/**
+ * Formats the modified-date subline for a project row, e.g. `"Modified Jan 1, 2026, 12:00 PM"`. The
+ * prefix is a localized label; the timestamp is rendered in the user's locale via
+ * `toLocaleString`.
+ *
+ * @param prefix - Localized `"Modified"` label to precede the date.
+ * @param updatedAt - ISO 8601 modification timestamp.
+ * @returns The prefix followed by the locale-formatted timestamp.
+ */
+function formatModified(prefix: string, updatedAt: string): string {
+  return `${prefix} ${new Date(updatedAt).toLocaleString()}`;
+}
 
 /**
  * Modal that lists all existing interlinearizer projects for a source project and lets the user
@@ -89,7 +103,11 @@ export function SelectInterlinearProjectModal({
           'Interlinearizer: skipped malformed project entries',
           parsed.length - valid.length,
         );
-      setProjects(valid);
+      // Most-recently-modified first so the project the user is likeliest to reopen sits at the top
+      // and the modified date reads as a meaningful distinguisher between otherwise-identical
+      // unnamed projects.
+      const sorted = [...valid].sort((a, b) => b.updatedAt.localeCompare(a.updatedAt));
+      setProjects(sorted);
     } catch (e) {
       logger.error('Interlinearizer: failed to load projects for source', e);
       await papi.notifications
@@ -126,24 +144,32 @@ export function SelectInterlinearProjectModal({
                 <button
                   type="button"
                   aria-current={isActive ? 'true' : undefined}
-                  className={`tw:flex-1 tw:flex tw:items-center tw:gap-2 tw:rounded tw:border tw:px-3 tw:py-2 tw:text-left tw:text-sm tw:transition-colors tw:min-w-0 ${
+                  className={`tw:flex-1 tw:flex tw:flex-col tw:gap-0.5 tw:rounded tw:border tw:px-3 tw:py-2 tw:text-left tw:text-sm tw:transition-colors tw:min-w-0 ${
                     isActive
                       ? 'tw:border-primary tw:bg-primary/10 tw:hover:bg-primary/20'
                       : 'tw:border-border tw:bg-muted/40 tw:hover:bg-muted/70'
                   }`}
                   onClick={() => onSelect(project)}
                 >
-                  <span className="tw:font-medium tw:text-foreground tw:truncate">
-                    {project.name ??
-                      localizedStrings['%interlinearizer_modal_select_name_unnamed%']}
-                  </span>
-                  {isActive && (
-                    <span className="tw:shrink-0 tw:rounded tw:bg-primary tw:px-1.5 tw:py-0.5 tw:text-xs tw:font-medium tw:text-primary-foreground">
-                      {localizedStrings['%interlinearizer_modal_select_active_badge%']}
+                  <span className="tw:flex tw:items-center tw:gap-2 tw:min-w-0">
+                    <span className="tw:font-medium tw:text-foreground tw:truncate">
+                      {project.name ??
+                        localizedStrings['%interlinearizer_modal_select_name_unnamed%']}
                     </span>
-                  )}
-                  <span className="tw:font-mono tw:text-xs tw:text-muted-foreground tw:shrink-0 tw:ms-auto">
-                    {project.analysisLanguages.join(', ')}
+                    {isActive && (
+                      <span className="tw:shrink-0 tw:rounded tw:bg-primary tw:px-1.5 tw:py-0.5 tw:text-xs tw:font-medium tw:text-primary-foreground">
+                        {localizedStrings['%interlinearizer_modal_select_active_badge%']}
+                      </span>
+                    )}
+                    <span className="tw:font-mono tw:text-xs tw:text-muted-foreground tw:shrink-0 tw:ms-auto">
+                      {project.analysisLanguages.join(', ')}
+                    </span>
+                  </span>
+                  <span className="tw:text-xs tw:text-muted-foreground">
+                    {formatModified(
+                      localizedStrings['%interlinearizer_modal_select_modified_prefix%'],
+                      project.updatedAt,
+                    )}
                   </span>
                 </button>
                 <Button

--- a/src/main.ts
+++ b/src/main.ts
@@ -268,7 +268,9 @@ async function getInterlinearProject(interlinearProjectId: string): Promise<stri
  * @param analysisJson - JSON-stringified `TextAnalysis` to persist.
  * @param segmentationJson - Optional JSON-stringified `SegmentationDelta` to persist, or `"null"`
  *   to clear stored boundaries. Omit to leave the project's existing boundaries unchanged.
- * @returns A promise that resolves when the analysis has been written to storage.
+ * @returns The saved `InterlinearProject` (carrying the refreshed `updatedAt`) as a JSON string, or
+ *   `undefined` if no project with the given ID exists. Returned so the WebView can refresh its
+ *   cached Modified time without a second read.
  * @throws If JSON parsing, validation, or storage fails. The error is logged and an error
  *   notification is sent before rethrowing so the frontend `catch` block can suppress it without a
  *   second notification.
@@ -277,7 +279,7 @@ async function saveInterlinearAnalysis(
   interlinearProjectId: string,
   analysisJson: string,
   segmentationJson?: string,
-): Promise<void> {
+): Promise<string | undefined> {
   try {
     const analysis = JSON.parse(analysisJson);
     if (!isTextAnalysis(analysis)) {
@@ -299,12 +301,13 @@ async function saveInterlinearAnalysis(
         );
       }
     }
-    await projectStorage.updateAnalysis(
+    const updated = await projectStorage.updateAnalysis(
       executionToken,
       interlinearProjectId,
       analysis,
       segmentation,
     );
+    return updated ? JSON.stringify(updated) : undefined;
   } catch (e) {
     logger.error('Interlinearizer: failed to save analysis', e);
     await papi.notifications
@@ -580,7 +583,12 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
             schema: { type: 'string' },
           },
         ],
-        result: { name: 'return value', summary: 'void', schema: { type: 'null' } },
+        result: {
+          name: 'return value',
+          summary:
+            'JSON-stringified InterlinearProject with the refreshed updatedAt, or undefined if not found',
+          schema: { type: 'string' },
+        },
       },
     },
   );

--- a/src/services/projectStorage.ts
+++ b/src/services/projectStorage.ts
@@ -141,7 +141,8 @@ async function readIds(token: ExecutionToken): Promise<string[]> {
 
 /**
  * Creates a new interlinearizer project with empty analysis data and writes it to extension
- * storage. Appends the project ID to the stored index.
+ * storage. Appends the project ID to the stored index. `createdAt` and `updatedAt` are set to the
+ * same creation timestamp.
  *
  * @param token - The execution token for storage access.
  * @param sourceProjectId - The Platform.Bible project ID of the source text.
@@ -166,9 +167,11 @@ export async function createProject(
   description?: string,
 ): Promise<InterlinearProject> {
   const id = crypto.randomUUID();
+  const now = new Date().toISOString();
   const project: InterlinearProject = {
     id,
-    createdAt: new Date().toISOString(),
+    createdAt: now,
+    updatedAt: now,
     ...(name !== undefined && { name }),
     ...(description !== undefined && { description }),
     sourceProjectId,
@@ -262,7 +265,7 @@ export async function getProjectsForSource(
 
 /**
  * Replaces the analysis of an existing interlinearizer project, and optionally its custom segment
- * boundaries, in one atomic write.
+ * boundaries, in one atomic write. Refreshes `updatedAt` to the current time.
  *
  * @param token - The execution token for storage access.
  * @param id - The interlinearizer project UUID to update.
@@ -283,7 +286,11 @@ export async function updateAnalysis(
   return enqueueProjectOp(id, async () => {
     const project = await getProject(token, id);
     if (!project) return undefined;
-    const updated: InterlinearProject = { ...project, analysis };
+    const updated: InterlinearProject = {
+      ...project,
+      analysis,
+      updatedAt: new Date().toISOString(),
+    };
     // eslint-disable-next-line no-null/no-null -- null is the explicit "clear stored boundaries" sentinel
     if (segmentation === null) delete updated.segmentation;
     else if (segmentation !== undefined) updated.segmentation = segmentation;
@@ -293,7 +300,8 @@ export async function updateAnalysis(
 }
 
 /**
- * Updates the metadata of an existing interlinearizer project.
+ * Updates the metadata of an existing interlinearizer project. Refreshes `updatedAt` to the current
+ * time.
  *
  * @param token - The execution token for storage access.
  * @param id - The interlinearizer project UUID to update.
@@ -319,7 +327,7 @@ export async function updateProjectMetadata(
   return enqueueProjectOp(id, async () => {
     const project = await getProject(token, id);
     if (!project) return undefined;
-    const updated: InterlinearProject = { ...project };
+    const updated: InterlinearProject = { ...project, updatedAt: new Date().toISOString() };
     if (name === undefined) {
       delete updated.name;
     } else {

--- a/src/types/interlinear-project-summary.ts
+++ b/src/types/interlinear-project-summary.ts
@@ -5,6 +5,7 @@ export type InterlinearProjectSummary = Pick<
   InterlinearProject,
   | 'id'
   | 'createdAt'
+  | 'updatedAt'
   | 'sourceProjectId'
   | 'targetProjectId'
   | 'analysisLanguages'

--- a/src/types/interlinear-project-summary.ts
+++ b/src/types/interlinear-project-summary.ts
@@ -12,3 +12,28 @@ export type InterlinearProjectSummary = Pick<
   | 'name'
   | 'description'
 >;
+
+/**
+ * Projects a summary-shaped value down to exactly the {@link InterlinearProjectSummary} fields,
+ * dropping any extra properties. Command responses that return a full `InterlinearProject` (with
+ * its potentially large `analysis`, plus `links` / `segmentation`) are structurally assignable to
+ * `InterlinearProjectSummary`, so caching one verbatim would persist the whole envelope in WebView
+ * state. This copies only the summary fields so the cached active project stays lean.
+ *
+ * @param summary - A value already narrowed to `InterlinearProjectSummary` (e.g. via
+ *   `isInterlinearProjectSummary`); it may still carry extra runtime properties.
+ * @returns A new object containing only the summary fields, with `targetProjectId` / `name` /
+ *   `description` present only when they are set on the input.
+ */
+export function toProjectSummary(summary: InterlinearProjectSummary): InterlinearProjectSummary {
+  return {
+    id: summary.id,
+    createdAt: summary.createdAt,
+    updatedAt: summary.updatedAt,
+    sourceProjectId: summary.sourceProjectId,
+    analysisLanguages: summary.analysisLanguages,
+    ...(summary.targetProjectId !== undefined && { targetProjectId: summary.targetProjectId }),
+    ...(summary.name !== undefined && { name: summary.name }),
+    ...(summary.description !== undefined && { description: summary.description }),
+  };
+}

--- a/src/types/interlinear-project-summary.ts
+++ b/src/types/interlinear-project-summary.ts
@@ -14,14 +14,16 @@ export type InterlinearProjectSummary = Pick<
 >;
 
 /**
- * Projects a summary-shaped value down to exactly the {@link InterlinearProjectSummary} fields,
- * dropping any extra properties. Command responses that return a full `InterlinearProject` (with
- * its potentially large `analysis`, plus `links` / `segmentation`) are structurally assignable to
- * `InterlinearProjectSummary`, so caching one verbatim would persist the whole envelope in WebView
- * state. This copies only the summary fields so the cached active project stays lean.
+ * Rebuilds a new object holding only the {@link InterlinearProjectSummary} fields. The parameter is
+ * statically typed as `InterlinearProjectSummary`, but structural typing lets a full
+ * `InterlinearProject` (with its potentially large `analysis`, plus `links` / `segmentation`)
+ * satisfy that type, so at runtime the argument may still carry those extra properties. Caching
+ * such a value verbatim would persist the whole envelope in WebView state; copying only the summary
+ * fields keeps the cached active project lean.
  *
- * @param summary - A value already narrowed to `InterlinearProjectSummary` (e.g. via
- *   `isInterlinearProjectSummary`); it may still carry extra runtime properties.
+ * @param summary - A value typed as `InterlinearProjectSummary` (e.g. narrowed via
+ *   `isInterlinearProjectSummary`) that may carry extra runtime properties from a wider
+ *   `InterlinearProject`.
  * @returns A new object containing only the summary fields, with `targetProjectId` / `name` /
  *   `description` present only when they are set on the input.
  */

--- a/src/types/interlinearizer.d.ts
+++ b/src/types/interlinearizer.d.ts
@@ -169,7 +169,9 @@ declare module 'papi-shared-types' {
      * @param segmentationJson Optional JSON-stringified `SegmentationDelta` to persist, or the
      *   string `"null"` to clear any stored custom boundaries. Omit entirely to leave the project's
      *   existing boundaries unchanged.
-     * @returns Promise that resolves to void once the analysis has been written to storage.
+     * @returns The saved `InterlinearProject` (with its refreshed `updatedAt`) as a JSON string, or
+     *   `undefined` if no project with the given ID exists. The WebView uses the refreshed
+     *   `updatedAt` to keep the cached Modified time current after a Save.
      * @throws If JSON parsing or storage fails. Error is logged and an error notification is sent
      *   before rethrowing so callers do not need to send a second notification.
      */
@@ -177,7 +179,7 @@ declare module 'papi-shared-types' {
       interlinearProjectId: string,
       analysisJson: string,
       segmentationJson?: string,
-    ) => Promise<void>;
+    ) => Promise<string | undefined>;
 
     /**
      * Returns the draft working buffer for the given source project, serialized as a JSON string.

--- a/src/types/interlinearizer.d.ts
+++ b/src/types/interlinearizer.d.ts
@@ -1205,6 +1205,13 @@ declare module 'interlinearizer' {
     /** ISO 8601 creation timestamp. */
     createdAt: string;
 
+    /**
+     * ISO 8601 timestamp of the most recent modification. Set to `createdAt` at creation and
+     * refreshed on every metadata or analysis/segmentation write. Used to sort the project picker
+     * by recency and to distinguish otherwise-identical unnamed projects.
+     */
+    updatedAt: string;
+
     /** Optional user-facing name for the project. */
     name?: string;
 

--- a/src/types/type-guards.ts
+++ b/src/types/type-guards.ts
@@ -33,6 +33,8 @@ export function isInterlinearProjectSummary(p: unknown): p is InterlinearProject
     typeof p.id === 'string' &&
     'createdAt' in p &&
     typeof p.createdAt === 'string' &&
+    'updatedAt' in p &&
+    typeof p.updatedAt === 'string' &&
     'sourceProjectId' in p &&
     typeof p.sourceProjectId === 'string' &&
     'analysisLanguages' in p &&

--- a/src/utils/project-summary-format.ts
+++ b/src/utils/project-summary-format.ts
@@ -1,0 +1,45 @@
+/**
+ * @file Shared formatting and sorting helpers for interlinear project summaries, used by the
+ *   project-selection and Save As modals so both lists order and label projects identically.
+ */
+
+/**
+ * Parses an ISO 8601 timestamp to epoch milliseconds, treating an unparsable string as `0`. The
+ * summary type guard only checks that `updatedAt` is a string, so a corrupted value could otherwise
+ * yield `NaN` and make the sort comparator's result undefined; normalizing to `0` keeps ordering
+ * deterministic (corrupted entries sort last).
+ *
+ * @param value - The timestamp string to parse.
+ * @returns The parsed epoch milliseconds, or `0` when `value` is not a valid date.
+ */
+export function parseUpdatedAt(value: string): number {
+  const time = Date.parse(value);
+  return Number.isNaN(time) ? 0 : time;
+}
+
+/**
+ * Compares two ISO 8601 timestamps for a descending (newest-first) sort by their parsed epoch
+ * milliseconds, so ordering is locale-independent (unlike `localeCompare`, whose result can vary by
+ * collator).
+ *
+ * @param a - The first ISO 8601 timestamp.
+ * @param b - The second ISO 8601 timestamp.
+ * @returns A negative number when `a` is newer than `b` (sorts first), positive when older, `0`
+ *   when the two timestamps are equal.
+ */
+export function compareUpdatedAtDescending(a: string, b: string): number {
+  return parseUpdatedAt(b) - parseUpdatedAt(a);
+}
+
+/**
+ * Formats the modified-date subline for a project row, e.g. `"Modified Jan 1, 2026, 12:00 PM"`. The
+ * prefix is a localized label; the timestamp is rendered in the user's locale via
+ * `toLocaleString`.
+ *
+ * @param prefix - Localized `"Modified"` label to precede the date.
+ * @param updatedAt - ISO 8601 modification timestamp.
+ * @returns The prefix followed by the locale-formatted timestamp.
+ */
+export function formatModified(prefix: string, updatedAt: string): string {
+  return `${prefix} ${new Date(updatedAt).toLocaleString()}`;
+}


### PR DESCRIPTION
<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/153)
<!-- Reviewable:end -->

Screenshots of added project details in modal list:
<img width="525" height="266" alt="Screenshot 2026-07-17 160116" src="https://github.com/user-attachments/assets/ed39ee47-9e6c-4f04-a359-7e9c22c19e97" />
<img width="521" height="539" alt="Screenshot 2026-07-17 160145" src="https://github.com/user-attachments/assets/1a7be50b-3228-4ebf-8ef5-994570b170f3" />

## Devin review

https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/153

### Summary as of 300b72a

This PR adds an updatedAt modification timestamp to interlinear projects, threading it through every layer:

1. Type model: InterlinearProject gains updatedAt: string; the summary type and type guard pick it up; a new toProjectSummary() strips full projects to lean cached summaries.
2. Storage: createProject sets updatedAt = createdAt; updateAnalysis and updateProjectMetadata refresh it to new Date().
Command: saveAnalysis changes from Promise<void> → Promise<string | undefined>, returning the saved project JSON so the WebView can read the refreshed timestamp without a second fetch.
3. Caching: InterlinearizerLoader and ProjectModals fold the server-returned updatedAt into the cached activeProject after every save path (direct save, save-as-new, overwrite, metadata edit). When the server returns undefined (project gone), the draft stays dirty.
4. UI: A new shared ProjectSummaryDetails component displays name + active badge + languages + modified date in both the Select and Save As modals. Projects sort newest-first via compareUpdatedAtDescending. The metadata modal shows a "Modified" row.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Project details now display when a project was last modified.
  * Project lists show “Modified” dates and sort projects from newest to oldest.
  * The active project is clearly identified when selecting an overwrite target.
  * Saving analysis or project metadata refreshes the displayed modification time.
  * Custom segmentation changes are preserved when saving projects.

* **Bug Fixes**
  * Missing or invalid save responses no longer incorrectly mark drafts as synchronized.
  * Project summaries now consistently retain refreshed metadata after save operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->