### PR TITLE
Sweep project records orphaned by failed index rollback (#141)

### DIFF
--- a/src/__tests__/main.test.ts
+++ b/src/__tests__/main.test.ts
@@ -223,6 +223,7 @@ describe('main', () => {
     __mockOnDidOpenWebView.mockReturnValue(jest.fn());
     __mockOnDidCloseWebView.mockReturnValue(jest.fn());
     __mockNotificationsSend.mockResolvedValue('mock-notification-id');
+    jest.mocked(projectStorage.sweepPendingCleanup).mockResolvedValue(0);
   });
 
   describe('activate', () => {
@@ -232,6 +233,33 @@ describe('main', () => {
 
       const raw: unknown = jest.mocked(__mockRegisterWebViewProvider).mock.calls[0]?.[1];
       expect(isWebViewProvider(raw)).toBe(true);
+    });
+
+    it('runs the pending-cleanup sweep with the execution token', async () => {
+      const context = createTestActivationContext();
+
+      await activate(context);
+
+      expect(jest.mocked(projectStorage.sweepPendingCleanup)).toHaveBeenCalledWith(
+        context.executionToken,
+      );
+    });
+
+    it('logs but does not fail activation when the pending-cleanup sweep rejects', async () => {
+      jest
+        .mocked(projectStorage.sweepPendingCleanup)
+        .mockRejectedValue(new Error('sweep exploded'));
+      const context = createTestActivationContext();
+
+      await expect(activate(context)).resolves.toBeUndefined();
+
+      // The rejection resolves on a later microtask than activate()'s synchronous body, so let the
+      // fire-and-forget catch handler run before asserting it logged.
+      await Promise.resolve();
+      expect(__mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('pending-cleanup sweep failed'),
+        expect.any(Error),
+      );
     });
 
     it('registers the interlinearizer.openForWebView command with a callable handler', async () => {

--- a/src/__tests__/services/projectStorage.test.ts
+++ b/src/__tests__/services/projectStorage.test.ts
@@ -860,6 +860,18 @@ describe('projectStorage', () => {
       await expect(listProjects(token)).rejects.toThrow(SyntaxError);
     });
 
+    it('throws a corruption error when the projectIds index is not an array', async () => {
+      __mockReadUserData.mockResolvedValue(JSON.stringify({ not: 'an array' }));
+
+      await expect(listProjects(token)).rejects.toThrow(/index is corrupt/);
+    });
+
+    it('throws a corruption error when the projectIds index holds non-strings', async () => {
+      __mockReadUserData.mockResolvedValue(JSON.stringify([1, 2, 3]));
+
+      await expect(listProjects(token)).rejects.toThrow(/index is corrupt/);
+    });
+
     it('skips a project whose storage value is corrupt JSON and logs the error', async () => {
       __mockReadUserData
         .mockResolvedValueOnce(JSON.stringify(['abc']))

--- a/src/__tests__/services/projectStorage.test.ts
+++ b/src/__tests__/services/projectStorage.test.ts
@@ -11,6 +11,7 @@ import {
   listProjects,
   resetQueuesForTesting,
   saveDraft,
+  sweepPendingCleanup,
   updateAnalysis,
   updateProjectMetadata,
 } from '../../services/projectStorage';
@@ -191,6 +192,78 @@ describe('projectStorage', () => {
       await expect(createProject(token, 'src-proj', ['en'])).rejects.toThrow('disk full');
 
       expect(__mockLogger.error).toHaveBeenCalled();
+    });
+
+    it('records the orphaned project for cleanup when rollback fails', async () => {
+      // Index read (ENOENT → []) and the later pendingCleanup read (ENOENT → []) both miss.
+      __mockReadUserData.mockRejectedValue(enoentError());
+      __mockWriteUserData
+        .mockResolvedValueOnce(undefined) // project write succeeds
+        .mockRejectedValueOnce(new Error('disk full')); // index write fails
+      __mockDeleteUserData.mockRejectedValue(new Error('rollback failed'));
+
+      await expect(createProject(token, 'src-proj', ['en'])).rejects.toThrow('disk full');
+
+      expect(__mockWriteUserData).toHaveBeenCalledWith(
+        token,
+        'pendingCleanup',
+        JSON.stringify(['00000000-0000-0000-0000-000000000001']),
+      );
+    });
+
+    it('logs and swallows a failure to record the orphan so the index error still surfaces', async () => {
+      __mockReadUserData.mockRejectedValue(enoentError());
+      // project write ok; index write fails; pendingCleanup write also fails.
+      __mockWriteUserData
+        .mockResolvedValueOnce(undefined)
+        .mockRejectedValueOnce(new Error('disk full'))
+        .mockRejectedValueOnce(new Error('cleanup write failed'));
+      __mockDeleteUserData.mockRejectedValue(new Error('rollback failed'));
+
+      await expect(createProject(token, 'src-proj', ['en'])).rejects.toThrow('disk full');
+
+      expect(__mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('record orphaned project'),
+        expect.any(Error),
+      );
+    });
+
+    it('does not re-record an orphan already in the pending-cleanup set', async () => {
+      const orphanId = '00000000-0000-0000-0000-000000000001';
+      // Index read → ENOENT ([]); pendingCleanup read → already contains this orphan.
+      __mockReadUserData.mockImplementation((_t: unknown, key: unknown) =>
+        key === 'pendingCleanup'
+          ? Promise.resolve(JSON.stringify([orphanId]))
+          : Promise.reject(enoentError()),
+      );
+      __mockWriteUserData
+        .mockResolvedValueOnce(undefined) // project write succeeds
+        .mockRejectedValueOnce(new Error('disk full')); // index write fails
+      __mockDeleteUserData.mockRejectedValue(new Error('rollback failed'));
+
+      await expect(createProject(token, 'src-proj', ['en'])).rejects.toThrow('disk full');
+
+      expect(__mockWriteUserData).not.toHaveBeenCalledWith(
+        token,
+        'pendingCleanup',
+        expect.anything(),
+      );
+    });
+
+    it('does not record the orphan when the rollback delete succeeds', async () => {
+      __mockReadUserData.mockRejectedValue(enoentError());
+      __mockWriteUserData
+        .mockResolvedValueOnce(undefined) // project write succeeds
+        .mockRejectedValueOnce(new Error('disk full')); // index write fails
+      // deleteUserData resolves (default mock) → rollback succeeds, nothing to record.
+
+      await expect(createProject(token, 'src-proj', ['en'])).rejects.toThrow('disk full');
+
+      expect(__mockWriteUserData).not.toHaveBeenCalledWith(
+        token,
+        'pendingCleanup',
+        expect.anything(),
+      );
     });
   });
 
@@ -442,6 +515,91 @@ describe('projectStorage', () => {
       await deleteProject(token, 'nonexistent-id');
 
       expect(__mockWriteUserData).toHaveBeenCalledWith(token, 'projectIds', JSON.stringify([]));
+    });
+  });
+
+  describe('sweepPendingCleanup', () => {
+    /**
+     * Makes `readUserData` return `pendingCleanup` as the given id list and ENOENT for every other
+     * key, so a sweep sees exactly `ids` as its work set.
+     *
+     * @param ids - The project IDs the pending-cleanup set should contain.
+     */
+    function stubPendingCleanup(ids: string[]): void {
+      __mockReadUserData.mockImplementation((_t: unknown, key: unknown) =>
+        key === 'pendingCleanup'
+          ? Promise.resolve(JSON.stringify(ids))
+          : Promise.reject(enoentError()),
+      );
+    }
+
+    it('returns 0 and writes nothing when the set is empty', async () => {
+      stubPendingCleanup([]);
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(cleaned).toBe(0);
+      expect(__mockDeleteUserData).not.toHaveBeenCalled();
+      expect(__mockWriteUserData).not.toHaveBeenCalled();
+    });
+
+    it('deletes each recorded record and clears the set on full success', async () => {
+      stubPendingCleanup(['orphan-a', 'orphan-b']);
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(cleaned).toBe(2);
+      expect(__mockDeleteUserData).toHaveBeenCalledWith(token, 'project:orphan-a');
+      expect(__mockDeleteUserData).toHaveBeenCalledWith(token, 'project:orphan-b');
+      expect(__mockWriteUserData).toHaveBeenCalledWith(token, 'pendingCleanup', JSON.stringify([]));
+    });
+
+    it('treats an already-missing record (ENOENT) as successfully cleaned', async () => {
+      stubPendingCleanup(['gone']);
+      __mockDeleteUserData.mockRejectedValue(enoentError());
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(cleaned).toBe(1);
+      expect(__mockWriteUserData).toHaveBeenCalledWith(token, 'pendingCleanup', JSON.stringify([]));
+    });
+
+    it('retains an id whose deletion fails again and logs it', async () => {
+      stubPendingCleanup(['stubborn', 'ok']);
+      __mockDeleteUserData.mockImplementation((_t: unknown, key: unknown) =>
+        key === 'project:stubborn'
+          ? Promise.reject(new Error('still locked'))
+          : Promise.resolve(undefined),
+      );
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(cleaned).toBe(1);
+      expect(__mockWriteUserData).toHaveBeenCalledWith(
+        token,
+        'pendingCleanup',
+        JSON.stringify(['stubborn']),
+      );
+      expect(__mockLogger.error).toHaveBeenCalledWith(
+        expect.stringContaining('stubborn'),
+        expect.any(Error),
+      );
+    });
+
+    it('propagates a non-ENOENT error from reading the pending-cleanup set', async () => {
+      __mockReadUserData.mockRejectedValue(new Error('disk full'));
+
+      await expect(sweepPendingCleanup(token)).rejects.toThrow('disk full');
+    });
+
+    it('does not rewrite the set when no ids could be cleaned', async () => {
+      stubPendingCleanup(['stubborn']);
+      __mockDeleteUserData.mockRejectedValue(new Error('still locked'));
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(cleaned).toBe(0);
+      expect(__mockWriteUserData).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/services/projectStorage.test.ts
+++ b/src/__tests__/services/projectStorage.test.ts
@@ -634,7 +634,7 @@ describe('projectStorage', () => {
       expect(__mockWriteUserData).toHaveBeenCalledWith(token, 'pendingCleanup', JSON.stringify([]));
     });
 
-    it('resets a pending-cleanup value containing invalid JSON to empty instead of wedging', async () => {
+    it('self-heals a pending-cleanup value containing invalid JSON by rewriting it to an empty set', async () => {
       __mockReadUserData.mockImplementation((_t: unknown, key: unknown) =>
         key === 'pendingCleanup' ? Promise.resolve('{ not json') : Promise.reject(enoentError()),
       );
@@ -644,9 +644,11 @@ describe('projectStorage', () => {
       expect(cleaned).toBe(0);
       expect(__mockDeleteUserData).not.toHaveBeenCalled();
       expect(__mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'));
+      // The corrupt value is overwritten so it is not re-read and re-warned about on every launch.
+      expect(__mockWriteUserData).toHaveBeenCalledWith(token, 'pendingCleanup', JSON.stringify([]));
     });
 
-    it('resets a pending-cleanup value that is not an array of strings to empty', async () => {
+    it('self-heals a pending-cleanup value that is not an array of strings by rewriting it to an empty set', async () => {
       __mockReadUserData.mockImplementation((_t: unknown, key: unknown) =>
         key === 'pendingCleanup'
           ? Promise.resolve(JSON.stringify([1, 2, 3]))
@@ -658,6 +660,8 @@ describe('projectStorage', () => {
       expect(cleaned).toBe(0);
       expect(__mockDeleteUserData).not.toHaveBeenCalled();
       expect(__mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('not an array'));
+      // The corrupt value is overwritten so it is not re-read and re-warned about on every launch.
+      expect(__mockWriteUserData).toHaveBeenCalledWith(token, 'pendingCleanup', JSON.stringify([]));
     });
   });
 

--- a/src/__tests__/services/projectStorage.test.ts
+++ b/src/__tests__/services/projectStorage.test.ts
@@ -601,6 +601,64 @@ describe('projectStorage', () => {
       expect(cleaned).toBe(0);
       expect(__mockWriteUserData).not.toHaveBeenCalled();
     });
+
+    it('never deletes the record of an id still present in the index', async () => {
+      // 'live' is both recorded for cleanup and still in the index (e.g. an index write that
+      // persisted but reported failure). Its backing record must not be deleted.
+      __mockReadUserData.mockImplementation((_t: unknown, key: unknown) => {
+        if (key === 'pendingCleanup') return Promise.resolve(JSON.stringify(['live', 'orphan']));
+        if (key === 'projectIds') return Promise.resolve(JSON.stringify(['live']));
+        return Promise.reject(enoentError());
+      });
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(__mockDeleteUserData).not.toHaveBeenCalledWith(token, 'project:live');
+      expect(__mockDeleteUserData).toHaveBeenCalledWith(token, 'project:orphan');
+      // 'live' is only a real orphan record when deleted; it was skipped, so it is not counted.
+      expect(cleaned).toBe(1);
+    });
+
+    it('drops a live id from the set without counting or deleting it', async () => {
+      __mockReadUserData.mockImplementation((_t: unknown, key: unknown) => {
+        if (key === 'pendingCleanup') return Promise.resolve(JSON.stringify(['live']));
+        if (key === 'projectIds') return Promise.resolve(JSON.stringify(['live']));
+        return Promise.reject(enoentError());
+      });
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(cleaned).toBe(0);
+      expect(__mockDeleteUserData).not.toHaveBeenCalled();
+      // The set is rewritten to drop the non-orphan id even though nothing was deleted.
+      expect(__mockWriteUserData).toHaveBeenCalledWith(token, 'pendingCleanup', JSON.stringify([]));
+    });
+
+    it('resets a pending-cleanup value containing invalid JSON to empty instead of wedging', async () => {
+      __mockReadUserData.mockImplementation((_t: unknown, key: unknown) =>
+        key === 'pendingCleanup' ? Promise.resolve('{ not json') : Promise.reject(enoentError()),
+      );
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(cleaned).toBe(0);
+      expect(__mockDeleteUserData).not.toHaveBeenCalled();
+      expect(__mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('invalid JSON'));
+    });
+
+    it('resets a pending-cleanup value that is not an array of strings to empty', async () => {
+      __mockReadUserData.mockImplementation((_t: unknown, key: unknown) =>
+        key === 'pendingCleanup'
+          ? Promise.resolve(JSON.stringify([1, 2, 3]))
+          : Promise.reject(enoentError()),
+      );
+
+      const cleaned = await sweepPendingCleanup(token);
+
+      expect(cleaned).toBe(0);
+      expect(__mockDeleteUserData).not.toHaveBeenCalled();
+      expect(__mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining('not an array'));
+    });
   });
 
   describe('updateAnalysis', () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -410,6 +410,13 @@ export async function activate(context: ExecutionActivationContext): Promise<voi
 
   executionToken = context.executionToken;
 
+  // Opportunistically retry deleting any project records orphaned by a failed rollback on a prior
+  // run (see projectStorage.createProject). Fire-and-forget: a cleanup failure must never block or
+  // fail activation, and the sweep will run again on the next activation.
+  projectStorage.sweepPendingCleanup(executionToken).catch((e) => {
+    logger.error('Interlinearizer: pending-cleanup sweep failed during activation:', e);
+  });
+
   const mainWebViewProviderRegistration = await papi.webViewProviders.registerWebViewProvider(
     mainWebViewType,
     mainWebViewProvider,

--- a/src/services/projectStorage.ts
+++ b/src/services/projectStorage.ts
@@ -182,9 +182,20 @@ function isNotFound(e: unknown): boolean {
 }
 
 /**
- * Reads and JSON-parses the string-array stored at `key`, treating a never-written key as an empty
- * array. Shared by {@link readIds} and {@link readPendingCleanup}. Does not validate the parsed
- * shape; callers that must tolerate corruption layer their own validation on top.
+ * Type guard for a JSON-parsed value that must be an array of strings — the shape of both the
+ * `projectIds` index and the `pendingCleanup` set.
+ *
+ * @param value - The parsed value to test.
+ * @returns Whether `value` is an array whose every element is a string.
+ */
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((id) => typeof id === 'string');
+}
+
+/**
+ * Reads and JSON-parses the value stored at `key`, treating a never-written key as an empty array.
+ * Shared by {@link readIds} and {@link readPendingCleanup}. Returns the raw parsed value as `unknown`
+ * and does not validate that it is an array of strings; each caller validates the shape itself.
  *
  * @param token - The execution token for storage access.
  * @param key - The storage key to read.
@@ -193,7 +204,7 @@ function isNotFound(e: unknown): boolean {
  * @throws If `papi.storage.readUserData` rejects for any non-ENOENT reason (e.g. permission denied,
  *   I/O error).
  */
-async function readJsonArray(token: ExecutionToken, key: string): Promise<string[]> {
+async function readJsonArray(token: ExecutionToken, key: string): Promise<unknown> {
   try {
     return JSON.parse(await papi.storage.readUserData(token, key));
   } catch (e) {
@@ -203,17 +214,29 @@ async function readJsonArray(token: ExecutionToken, key: string): Promise<string
 }
 
 /**
- * Reads the stored list of project IDs.
+ * Reads the stored list of project IDs. Unlike the pending-cleanup set, a corrupt index is never
+ * silently reset to an empty array — that would drop every project's id at once and orphan all
+ * their records — so a stored value that is not an array of strings throws a clear corruption error
+ * rather than being coerced into subtle downstream failures (e.g. spreading a string into
+ * characters in {@link createProject}, or calling `.filter` on a non-array in
+ * {@link deleteProject}).
  *
  * @param token - The execution token for storage access.
  * @returns The stored project ID array, or an empty array if `projectIds` has never been written
  *   (ENOENT).
  * @throws {SyntaxError} If the `projectIds` storage value contains invalid JSON.
+ * @throws {Error} If the parsed `projectIds` value is not an array of strings (a corrupt index).
  * @throws If `papi.storage.readUserData` rejects for any non-ENOENT reason (e.g. permission denied,
  *   I/O error).
  */
-function readIds(token: ExecutionToken): Promise<string[]> {
-  return readJsonArray(token, PROJECT_IDS_KEY);
+async function readIds(token: ExecutionToken): Promise<string[]> {
+  const parsed = await readJsonArray(token, PROJECT_IDS_KEY);
+  if (!isStringArray(parsed)) {
+    throw new Error(
+      `Interlinearizer: '${PROJECT_IDS_KEY}' index is corrupt (expected an array of strings)`,
+    );
+  }
+  return parsed;
 }
 
 /**
@@ -253,7 +276,7 @@ async function readPendingCleanup(token: ExecutionToken): Promise<PendingCleanup
     }
     throw e;
   }
-  if (!Array.isArray(parsed) || !parsed.every((id) => typeof id === 'string')) {
+  if (!isStringArray(parsed)) {
     logger.warn(
       'Interlinearizer: pending-cleanup set is not an array of strings; resetting to empty',
     );
@@ -317,6 +340,12 @@ export function sweepPendingCleanup(token: ExecutionToken): Promise<number> {
       if (corrupt) await papi.storage.writeUserData(token, PENDING_CLEANUP_KEY, JSON.stringify([]));
       return 0;
     }
+    // Read the index directly rather than through enqueueIndexOp: this snapshot is consulted only
+    // to protect live projects from deletion, and both directions of a stale read are safe. A read
+    // that misses a just-created project is harmless (a live project's id is never in the
+    // pending-cleanup work set), and a read that still shows a since-deleted project only makes the
+    // sweep conservatively skip a deletion. A stale snapshot can never make the sweep delete a
+    // record it should keep, so serializing this read would add contention for no benefit.
     const indexed = new Set(await readIds(token));
     // For each id, decide whether to keep it in the set and whether its record was cleaned.
     const outcomes = await Promise.all(

--- a/src/services/projectStorage.ts
+++ b/src/services/projectStorage.ts
@@ -48,8 +48,31 @@ const projectQueues = new Map<string, Promise<unknown>>();
 const draftQueues = new Map<string, Promise<unknown>>();
 
 /**
- * Enqueues `fn` on the index serialization queue and returns a promise that resolves or rejects
- * with `fn`'s result. The queue always advances regardless of whether `fn` throws.
+ * Enqueues `fn` on a single shared serialization queue and returns a promise that resolves or
+ * rejects with `fn`'s result. The queue always advances regardless of whether `fn` throws, so a
+ * failed operation does not block later ones. Shared by {@link enqueueIndexOp} and
+ * {@link enqueuePendingCleanupOp}, which differ only in which module-level queue they advance.
+ *
+ * @param get - Returns the current tail of the queue to chain `fn` after.
+ * @param set - Stores the new tail of the queue (a promise that settles once `fn` settles).
+ * @param fn - The async function to serialize.
+ * @returns A promise that resolves or rejects with the return value of `fn`.
+ * @throws Whatever `fn` throws; the queue advances past the error so later operations are not
+ *   blocked.
+ */
+function enqueueOnQueue<T>(
+  get: () => Promise<unknown>,
+  set: (queue: Promise<unknown>) => void,
+  fn: () => Promise<T>,
+): Promise<T> {
+  const result = get().then(fn);
+  set(result.catch(() => {}));
+  return result;
+}
+
+/**
+ * Enqueues `fn` on the index serialization queue. Thin wrapper over {@link enqueueOnQueue} bound to
+ * {@link indexQueue}.
  *
  * @param fn - The async function to serialize.
  * @returns A promise that resolves or rejects with the return value of `fn`.
@@ -57,14 +80,18 @@ const draftQueues = new Map<string, Promise<unknown>>();
  *   blocked.
  */
 function enqueueIndexOp<T>(fn: () => Promise<T>): Promise<T> {
-  const result = indexQueue.then(fn);
-  indexQueue = result.catch(() => {});
-  return result;
+  return enqueueOnQueue(
+    () => indexQueue,
+    (q) => {
+      indexQueue = q;
+    },
+    fn,
+  );
 }
 
 /**
- * Enqueues `fn` on the pending-cleanup serialization queue and returns a promise that resolves or
- * rejects with `fn`'s result. The queue always advances regardless of whether `fn` throws.
+ * Enqueues `fn` on the pending-cleanup serialization queue. Thin wrapper over {@link enqueueOnQueue}
+ * bound to {@link pendingCleanupQueue}.
  *
  * @param fn - The async function to serialize.
  * @returns A promise that resolves or rejects with the return value of `fn`.
@@ -72,9 +99,13 @@ function enqueueIndexOp<T>(fn: () => Promise<T>): Promise<T> {
  *   blocked.
  */
 function enqueuePendingCleanupOp<T>(fn: () => Promise<T>): Promise<T> {
-  const result = pendingCleanupQueue.then(fn);
-  pendingCleanupQueue = result.catch(() => {});
-  return result;
+  return enqueueOnQueue(
+    () => pendingCleanupQueue,
+    (q) => {
+      pendingCleanupQueue = q;
+    },
+    fn,
+  );
 }
 
 /**
@@ -151,6 +182,27 @@ function isNotFound(e: unknown): boolean {
 }
 
 /**
+ * Reads and JSON-parses the string-array stored at `key`, treating a never-written key as an empty
+ * array. Shared by {@link readIds} and {@link readPendingCleanup}. Does not validate the parsed
+ * shape; callers that must tolerate corruption layer their own validation on top.
+ *
+ * @param token - The execution token for storage access.
+ * @param key - The storage key to read.
+ * @returns The parsed value, or an empty array if `key` has never been written (ENOENT).
+ * @throws {SyntaxError} If the stored value contains invalid JSON.
+ * @throws If `papi.storage.readUserData` rejects for any non-ENOENT reason (e.g. permission denied,
+ *   I/O error).
+ */
+async function readJsonArray(token: ExecutionToken, key: string): Promise<string[]> {
+  try {
+    return JSON.parse(await papi.storage.readUserData(token, key));
+  } catch (e) {
+    if (isNotFound(e)) return [];
+    throw e;
+  }
+}
+
+/**
  * Reads the stored list of project IDs.
  *
  * @param token - The execution token for storage access.
@@ -160,31 +212,41 @@ function isNotFound(e: unknown): boolean {
  * @throws If `papi.storage.readUserData` rejects for any non-ENOENT reason (e.g. permission denied,
  *   I/O error).
  */
-async function readIds(token: ExecutionToken): Promise<string[]> {
-  try {
-    return JSON.parse(await papi.storage.readUserData(token, PROJECT_IDS_KEY));
-  } catch (e) {
-    if (isNotFound(e)) return [];
-    throw e;
-  }
+function readIds(token: ExecutionToken): Promise<string[]> {
+  return readJsonArray(token, PROJECT_IDS_KEY);
 }
 
 /**
- * Reads the stored set of orphaned project IDs awaiting cleanup.
+ * Reads the stored set of orphaned project IDs awaiting cleanup, tolerating corruption so a bad
+ * value can never wedge {@link sweepPendingCleanup} (which runs fire-and-forget at activation, where
+ * a thrown error would be invisible and would recur on every launch). A value that is missing
+ * (ENOENT), unparseable, or not an array of strings is treated as an empty set: the sweep then has
+ * nothing to do and its terminal rewrite replaces the bad value with a valid one, self-healing the
+ * key.
  *
  * @param token - The execution token for storage access.
- * @returns The stored pending-cleanup ID array, or an empty array if `pendingCleanup` has never
- *   been written (ENOENT).
- * @throws {SyntaxError} If the `pendingCleanup` storage value contains invalid JSON.
+ * @returns The stored pending-cleanup ID array, or an empty array when the value is missing or
+ *   corrupt.
  * @throws If `papi.storage.readUserData` rejects for any non-ENOENT reason.
  */
 async function readPendingCleanup(token: ExecutionToken): Promise<string[]> {
+  let parsed: unknown;
   try {
-    return JSON.parse(await papi.storage.readUserData(token, PENDING_CLEANUP_KEY));
+    parsed = await readJsonArray(token, PENDING_CLEANUP_KEY);
   } catch (e) {
-    if (isNotFound(e)) return [];
+    if (e instanceof SyntaxError) {
+      logger.warn('Interlinearizer: pending-cleanup set contains invalid JSON; resetting to empty');
+      return [];
+    }
     throw e;
   }
+  if (!Array.isArray(parsed) || !parsed.every((id) => typeof id === 'string')) {
+    logger.warn(
+      'Interlinearizer: pending-cleanup set is not an array of strings; resetting to empty',
+    );
+    return [];
+  }
+  return parsed;
 }
 
 /**
@@ -195,9 +257,9 @@ async function readPendingCleanup(token: ExecutionToken): Promise<string[]> {
  * @param token - The execution token for storage access.
  * @param id - The orphaned project UUID to record for later cleanup.
  * @returns A promise that resolves once the id has been persisted (or was already present).
- * @throws {SyntaxError} If the `pendingCleanup` storage value contains invalid JSON.
  * @throws If `papi.storage.readUserData` or `papi.storage.writeUserData` rejects for a non-ENOENT
- *   reason.
+ *   reason. A corrupt `pendingCleanup` value is not thrown; {@link readPendingCleanup} resets it to
+ *   an empty set.
  */
 function recordPendingCleanup(token: ExecutionToken, id: string): Promise<void> {
   return enqueuePendingCleanupOp(async () => {
@@ -209,10 +271,18 @@ function recordPendingCleanup(token: ExecutionToken, id: string): Promise<void> 
 
 /**
  * Retries deleting the orphaned project records recorded in the `pendingCleanup` set (see
- * {@link createProject}). For each recorded id, attempts to delete its `project:{id}` record,
- * treating ENOENT as success (the record is already gone). Ids whose deletion succeeds are removed
- * from the set; ids that fail again are left in place for the next attempt. Intended to run
- * opportunistically at activation.
+ * {@link createProject}). For each recorded id:
+ *
+ * - If the id is still present in the `projectIds` index, it belongs to a live project — its record
+ *   must not be deleted. The id is dropped from the set without touching its record; it should
+ *   never have been recorded (or has since become live) and is not an orphan to clean.
+ * - Otherwise the record is an orphan: its `project:{id}` deletion is attempted, treating ENOENT as
+ *   success (already gone). On success the id is dropped from the set; on failure it is retained
+ *   for the next attempt and logged.
+ *
+ * Consulting the index guards against destroying a live project's record if an id ever lands in the
+ * set while still indexed (e.g. an index write that persists but then reports failure). Intended to
+ * run opportunistically at activation.
  *
  * The whole read-delete-rewrite cycle is serialized through {@link pendingCleanupQueue} so it cannot
  * interleave with a concurrent {@link recordPendingCleanup} and drop a newly recorded orphan. The
@@ -220,8 +290,8 @@ function recordPendingCleanup(token: ExecutionToken, id: string): Promise<void> 
  * distinct key.
  *
  * @param token - The execution token for storage access.
- * @returns A promise resolving to the number of orphaned records successfully cleaned up this pass.
- * @throws {SyntaxError} If the `pendingCleanup` storage value contains invalid JSON.
+ * @returns A promise resolving to the number of orphaned records successfully deleted this pass
+ *   (live ids dropped from the set without deleting their record are not counted).
  * @throws If reading the set or rewriting it (`papi.storage.writeUserData`) rejects for a
  *   non-ENOENT reason. A per-record delete failure is not thrown; the id is retained instead.
  */
@@ -229,23 +299,30 @@ export function sweepPendingCleanup(token: ExecutionToken): Promise<number> {
   return enqueuePendingCleanupOp(async () => {
     const ids = await readPendingCleanup(token);
     if (ids.length === 0) return 0;
-    const deletions = await Promise.all(
+    const indexed = new Set(await readIds(token));
+    // For each id, decide whether to keep it in the set and whether its record was cleaned.
+    const outcomes = await Promise.all(
       ids.map(async (id) => {
+        if (indexed.has(id)) {
+          // Live project: never delete its record. Drop it from the set as a non-orphan.
+          logger.warn(`Interlinearizer: pending-cleanup id ${id} is a live project; not deleting`);
+          return { keep: false, cleaned: false };
+        }
         try {
           await papi.storage.deleteUserData(token, projectKey(id));
-          return true;
+          return { keep: false, cleaned: true };
         } catch (e) {
-          if (isNotFound(e)) return true;
+          if (isNotFound(e)) return { keep: false, cleaned: true };
           logger.error(`Interlinearizer: cleanup of orphaned project ${id} failed again:`, e);
-          return false;
+          return { keep: true, cleaned: false };
         }
       }),
     );
-    const remaining = ids.filter((_id, i) => !deletions[i]);
+    const remaining = ids.filter((_id, i) => outcomes[i].keep);
     if (remaining.length !== ids.length) {
       await papi.storage.writeUserData(token, PENDING_CLEANUP_KEY, JSON.stringify(remaining));
     }
-    return ids.length - remaining.length;
+    return outcomes.filter((o) => o.cleaned).length;
   });
 }
 

--- a/src/services/projectStorage.ts
+++ b/src/services/projectStorage.ts
@@ -217,26 +217,39 @@ function readIds(token: ExecutionToken): Promise<string[]> {
 }
 
 /**
+ * Outcome of reading the pending-cleanup set, distinguishing a genuinely-empty (or well-formed) set
+ * from a corrupt stored value. {@link sweepPendingCleanup} uses `corrupt` to decide whether it must
+ * overwrite the stored value even when there are no ids to process, so a bad value is repaired
+ * rather than re-read (and re-warned about) on every launch.
+ */
+interface PendingCleanupRead {
+  /** The recovered pending-cleanup ids: the parsed array, or `[]` when the stored value was corrupt. */
+  ids: string[];
+  /** Whether the stored value was unparseable or not an array of strings. */
+  corrupt: boolean;
+}
+
+/**
  * Reads the stored set of orphaned project IDs awaiting cleanup, tolerating corruption so a bad
  * value can never wedge {@link sweepPendingCleanup} (which runs fire-and-forget at activation, where
  * a thrown error would be invisible and would recur on every launch). A value that is missing
- * (ENOENT), unparseable, or not an array of strings is treated as an empty set: the sweep then has
- * nothing to do and its terminal rewrite replaces the bad value with a valid one, self-healing the
- * key.
+ * (ENOENT), unparseable, or not an array of strings is recovered as an empty set; when the value
+ * was present but corrupt, `corrupt` is set so the caller can rewrite the key with a valid value,
+ * self-healing it instead of re-reading (and re-warning about) the bad value on every launch.
  *
  * @param token - The execution token for storage access.
- * @returns The stored pending-cleanup ID array, or an empty array when the value is missing or
- *   corrupt.
+ * @returns The recovered ids and whether the stored value was corrupt. A missing (ENOENT) value is
+ *   an empty, non-corrupt set (nothing to repair).
  * @throws If `papi.storage.readUserData` rejects for any non-ENOENT reason.
  */
-async function readPendingCleanup(token: ExecutionToken): Promise<string[]> {
+async function readPendingCleanup(token: ExecutionToken): Promise<PendingCleanupRead> {
   let parsed: unknown;
   try {
     parsed = await readJsonArray(token, PENDING_CLEANUP_KEY);
   } catch (e) {
     if (e instanceof SyntaxError) {
       logger.warn('Interlinearizer: pending-cleanup set contains invalid JSON; resetting to empty');
-      return [];
+      return { ids: [], corrupt: true };
     }
     throw e;
   }
@@ -244,9 +257,9 @@ async function readPendingCleanup(token: ExecutionToken): Promise<string[]> {
     logger.warn(
       'Interlinearizer: pending-cleanup set is not an array of strings; resetting to empty',
     );
-    return [];
+    return { ids: [], corrupt: true };
   }
-  return parsed;
+  return { ids: parsed, corrupt: false };
 }
 
 /**
@@ -263,7 +276,7 @@ async function readPendingCleanup(token: ExecutionToken): Promise<string[]> {
  */
 function recordPendingCleanup(token: ExecutionToken, id: string): Promise<void> {
   return enqueuePendingCleanupOp(async () => {
-    const ids = await readPendingCleanup(token);
+    const { ids } = await readPendingCleanup(token);
     if (ids.includes(id)) return;
     await papi.storage.writeUserData(token, PENDING_CLEANUP_KEY, JSON.stringify([...ids, id]));
   });
@@ -297,8 +310,13 @@ function recordPendingCleanup(token: ExecutionToken, id: string): Promise<void> 
  */
 export function sweepPendingCleanup(token: ExecutionToken): Promise<number> {
   return enqueuePendingCleanupOp(async () => {
-    const ids = await readPendingCleanup(token);
-    if (ids.length === 0) return 0;
+    const { ids, corrupt } = await readPendingCleanup(token);
+    if (ids.length === 0) {
+      // Nothing to sweep. If the stored value was corrupt, overwrite it with a valid empty set so
+      // it self-heals; otherwise it would be re-read and re-warned about on every launch.
+      if (corrupt) await papi.storage.writeUserData(token, PENDING_CLEANUP_KEY, JSON.stringify([]));
+      return 0;
+    }
     const indexed = new Set(await readIds(token));
     // For each id, decide whether to keep it in the set and whether its record was cleaned.
     const outcomes = await Promise.all(

--- a/src/services/projectStorage.ts
+++ b/src/services/projectStorage.ts
@@ -12,11 +12,26 @@ import { isDraftProject } from '../types/type-guards';
 const PROJECT_IDS_KEY = 'projectIds';
 
 /**
+ * Storage key holding the set of project IDs whose records were orphaned by a failed rollback (see
+ * {@link createProject}). Each entry is a `project:{id}` record that was written but never added to
+ * the index and could not be deleted at the time; {@link sweepPendingCleanup} retries their
+ * deletion.
+ */
+const PENDING_CLEANUP_KEY = 'pendingCleanup';
+
+/**
  * Serializes all read-modify-write operations on the shared `projectIds` index. Every operation
  * that reads then writes the index must be enqueued here so concurrent calls (e.g. from two open
  * WebView tabs) cannot interleave at await boundaries and silently overwrite each other's updates.
  */
 let indexQueue: Promise<unknown> = Promise.resolve();
+
+/**
+ * Serializes all read-modify-write operations on the shared `pendingCleanup` set. Recording a new
+ * orphan (from a failed rollback) and the sweep that retries deletions must not interleave at await
+ * boundaries, or one could overwrite the other's changes to the set.
+ */
+let pendingCleanupQueue: Promise<unknown> = Promise.resolve();
 
 /**
  * Per-project serialization queues. Keyed by project ID; each entry serializes all
@@ -44,6 +59,21 @@ const draftQueues = new Map<string, Promise<unknown>>();
 function enqueueIndexOp<T>(fn: () => Promise<T>): Promise<T> {
   const result = indexQueue.then(fn);
   indexQueue = result.catch(() => {});
+  return result;
+}
+
+/**
+ * Enqueues `fn` on the pending-cleanup serialization queue and returns a promise that resolves or
+ * rejects with `fn`'s result. The queue always advances regardless of whether `fn` throws.
+ *
+ * @param fn - The async function to serialize.
+ * @returns A promise that resolves or rejects with the return value of `fn`.
+ * @throws Whatever `fn` throws; the queue advances past the error so later operations are not
+ *   blocked.
+ */
+function enqueuePendingCleanupOp<T>(fn: () => Promise<T>): Promise<T> {
+  const result = pendingCleanupQueue.then(fn);
+  pendingCleanupQueue = result.catch(() => {});
   return result;
 }
 
@@ -140,6 +170,86 @@ async function readIds(token: ExecutionToken): Promise<string[]> {
 }
 
 /**
+ * Reads the stored set of orphaned project IDs awaiting cleanup.
+ *
+ * @param token - The execution token for storage access.
+ * @returns The stored pending-cleanup ID array, or an empty array if `pendingCleanup` has never
+ *   been written (ENOENT).
+ * @throws {SyntaxError} If the `pendingCleanup` storage value contains invalid JSON.
+ * @throws If `papi.storage.readUserData` rejects for any non-ENOENT reason.
+ */
+async function readPendingCleanup(token: ExecutionToken): Promise<string[]> {
+  try {
+    return JSON.parse(await papi.storage.readUserData(token, PENDING_CLEANUP_KEY));
+  } catch (e) {
+    if (isNotFound(e)) return [];
+    throw e;
+  }
+}
+
+/**
+ * Records `id` in the persistent `pendingCleanup` set so a later {@link sweepPendingCleanup} can
+ * retry deleting its orphaned `project:{id}` record. Serialized through {@link pendingCleanupQueue}
+ * and idempotent: an id already in the set is not added twice.
+ *
+ * @param token - The execution token for storage access.
+ * @param id - The orphaned project UUID to record for later cleanup.
+ * @returns A promise that resolves once the id has been persisted (or was already present).
+ * @throws {SyntaxError} If the `pendingCleanup` storage value contains invalid JSON.
+ * @throws If `papi.storage.readUserData` or `papi.storage.writeUserData` rejects for a non-ENOENT
+ *   reason.
+ */
+function recordPendingCleanup(token: ExecutionToken, id: string): Promise<void> {
+  return enqueuePendingCleanupOp(async () => {
+    const ids = await readPendingCleanup(token);
+    if (ids.includes(id)) return;
+    await papi.storage.writeUserData(token, PENDING_CLEANUP_KEY, JSON.stringify([...ids, id]));
+  });
+}
+
+/**
+ * Retries deleting the orphaned project records recorded in the `pendingCleanup` set (see
+ * {@link createProject}). For each recorded id, attempts to delete its `project:{id}` record,
+ * treating ENOENT as success (the record is already gone). Ids whose deletion succeeds are removed
+ * from the set; ids that fail again are left in place for the next attempt. Intended to run
+ * opportunistically at activation.
+ *
+ * The whole read-delete-rewrite cycle is serialized through {@link pendingCleanupQueue} so it cannot
+ * interleave with a concurrent {@link recordPendingCleanup} and drop a newly recorded orphan. The
+ * per-record deletions run concurrently within the cycle; the set is small and each targets a
+ * distinct key.
+ *
+ * @param token - The execution token for storage access.
+ * @returns A promise resolving to the number of orphaned records successfully cleaned up this pass.
+ * @throws {SyntaxError} If the `pendingCleanup` storage value contains invalid JSON.
+ * @throws If reading the set or rewriting it (`papi.storage.writeUserData`) rejects for a
+ *   non-ENOENT reason. A per-record delete failure is not thrown; the id is retained instead.
+ */
+export function sweepPendingCleanup(token: ExecutionToken): Promise<number> {
+  return enqueuePendingCleanupOp(async () => {
+    const ids = await readPendingCleanup(token);
+    if (ids.length === 0) return 0;
+    const deletions = await Promise.all(
+      ids.map(async (id) => {
+        try {
+          await papi.storage.deleteUserData(token, projectKey(id));
+          return true;
+        } catch (e) {
+          if (isNotFound(e)) return true;
+          logger.error(`Interlinearizer: cleanup of orphaned project ${id} failed again:`, e);
+          return false;
+        }
+      }),
+    );
+    const remaining = ids.filter((_id, i) => !deletions[i]);
+    if (remaining.length !== ids.length) {
+      await papi.storage.writeUserData(token, PENDING_CLEANUP_KEY, JSON.stringify(remaining));
+    }
+    return ids.length - remaining.length;
+  });
+}
+
+/**
  * Creates a new interlinearizer project with empty analysis data and writes it to extension
  * storage. Appends the project ID to the stored index. `createdAt` and `updatedAt` are set to the
  * same creation timestamp.
@@ -155,8 +265,10 @@ async function readIds(token: ExecutionToken): Promise<string[]> {
  * @param description - Optional user-facing description for the project.
  * @returns The newly created project record.
  * @throws {SyntaxError} If the `projectIds` storage value contains invalid JSON.
- * @throws If `papi.storage.writeUserData` (project or index) or rollback via
- *   `papi.storage.deleteUserData` rejects for a non-ENOENT reason.
+ * @throws If the project or index `papi.storage.writeUserData` rejects. On an index-write failure
+ *   the original error is rethrown after best-effort rollback; a failed rollback does not throw —
+ *   the orphaned record is instead recorded for a later {@link sweepPendingCleanup} (and a failure
+ *   to even record it is logged and swallowed).
  */
 export async function createProject(
   token: ExecutionToken,
@@ -192,6 +304,12 @@ export async function createProject(
       await papi.storage.deleteUserData(token, projectKey(id));
     } catch (rollbackError) {
       logger.error(`Failed to roll back project ${id} after index write failure:`, rollbackError);
+      // The orphaned record was written but never indexed and could not be deleted. Record it so a
+      // later sweep retries the deletion; a failure to even record it is logged and swallowed so it
+      // never masks the original index error the caller needs to see.
+      await recordPendingCleanup(token, id).catch((recordError) => {
+        logger.error(`Failed to record orphaned project ${id} for cleanup:`, recordError);
+      });
     }
     throw indexError;
   }
@@ -439,6 +557,7 @@ export async function saveDraft(
  */
 export function resetQueuesForTesting(): void {
   indexQueue = Promise.resolve();
+  pendingCleanupQueue = Promise.resolve();
   projectQueues.clear();
   draftQueues.clear();
 }


### PR DESCRIPTION
createProject writes project:{id} before adding it to the projectIds index, and rolls the record back if the index write fails. If that rollback delete also fails, the record was orphaned forever — never listed, never deleted, pure storage bloat.

The PAPI storage API exposes only read/write/delete with no key enumeration, so reconciling live keys against the index isn't possible. Instead, record the orphaned id in a persistent pendingCleanup set on rollback failure, and retry the deletion opportunistically on the next activation via a fire-and-forget sweep.

- Add pendingCleanup storage key with its own serialization queue so recording an orphan and sweeping can't clobber each other's writes.
- recordPendingCleanup: idempotently add an orphan id; a failure to record is logged and swallowed so it never masks the original index error the caller must see.
- sweepPendingCleanup: retry each recorded delete (ENOENT = already gone = success), clear cleaned ids, retain ids that fail again.
- Guard the sweep against deleting live projects: an id still present in the projectIds index is dropped from the set without deleting its record, so a misrecorded (or since-revived) project is never destroyed.
- Tolerate and self-heal a corrupt pendingCleanup value: it is recovered as an empty set and rewritten to [], so a bad value can't wedge the fire-and-forget sweep or re-warn on every launch.
- Run the sweep at activation, fire-and-forget: a cleanup failure never blocks activation and it retries on the next run.
- Validate the projectIds index shape in readIds: a non-array-of-strings throws a clear corruption error instead of failing subtly (spreading a string into characters, or calling .filter on a non-array), and the sweep's live-project guard no longer misbehaves on a wrong-typed index.

---

Devin: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/154

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/154)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Reliability Improvements**
  * Added automatic background cleanup for incomplete project records from previous failed operations.
  * Cleanup now safely handles missing records and preserves items that require another attempt.
  * Corrupted cleanup data is repaired automatically.

* **Bug Fixes**
  * Improved project creation rollback so failed cleanup can be retried later.
  * Cleanup errors are logged without preventing the extension from activating or hiding the original project creation error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
