### PR TITLE
Suggested changes on expand-e2e-testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,13 +114,10 @@ jobs:
         working-directory: paranext-core
         run: npm run build:dll
 
-      # Both OSes run the FULL suite: smoke plus the CDP feature tests. `test:e2e:cdp` self-launches
-      # its own Platform.Bible instance (globalSetup, --remote-debugging-port=9223) and tears it down
-      # cross-platform (POSIX process-group SIGKILL on Linux, `taskkill /T /F` on Windows), so there
-      # is no separate app-start step on either OS. Linux additionally needs an xvfb display.
       - name: Run e2e tests (Linux)
         if: matrix.os == 'ubuntu-latest'
         working-directory: extension-repo
+        # Linux needs an xvfb display
         run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" npm run test:e2e
 
       - name: Run e2e tests (Windows)
@@ -135,7 +132,7 @@ jobs:
           name: playwright-results-${{ matrix.os }}
           retention-days: 7
           path: |
+            extension-repo/e2e-tests/.cdp-app-startup.log
             extension-repo/e2e-tests/playwright-report/
             extension-repo/e2e-tests/test-results/
-            extension-repo/e2e-tests/.cdp-app-startup.log
           if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -36,12 +36,8 @@ temp-build
 # AI files
 .claude
 
-# Playwright test output
+# Playwright output
+e2e-tests/.cdp-*
+e2e-tests/.dev-*
 e2e-tests/playwright-report
 e2e-tests/test-results
-
-# Playwright runtime process markers (dev server / self-launched CDP app)
-e2e-tests/.dev-server.pid
-e2e-tests/.cdp-app.pid
-e2e-tests/.cdp-app.user-data-dir
-e2e-tests/.cdp-app-startup.log

--- a/e2e-tests/README.md
+++ b/e2e-tests/README.md
@@ -9,7 +9,7 @@ Run everything with `npm run test:e2e` (smoke tier then CDP tier). Each tier can
 
 Both tiers are self-launching: the CDP tier's `globalSetup` launches its own Platform.Bible instance (with `--remote-debugging-port=9223`) in an isolated user-data dir and tears it down afterward, so `npm run test:e2e:cdp` needs no manual `npm run start:cdp` first. To iterate against a warm instance instead, run `npm run start:cdp` in one terminal, then run the CDP config directly with `npx playwright test --config e2e-tests/playwright-cdp.config.ts`: the setup detects the in-use CDP port, reuses that instance, and leaves it running.
 
-In CI (`.github/workflows/test.yml`, `e2e` job) the full suite runs on Linux under `xvfb` via `npm run test:e2e`; Windows runs the smoke tier only, because the CDP self-launch tears its app down by POSIX process group, which has no Windows equivalent. Each tier writes its Playwright HTML report to its own subfolder (`playwright-report/smoke`, `playwright-report/cdp`) so a combined run keeps both.
+In CI (`.github/workflows/test.yml`, `e2e` job) the full suite runs on both Linux and Windows. Each tier writes its Playwright HTML report to its own subfolder (`playwright-report/smoke`, `playwright-report/cdp`) so a combined run keeps both.
 
 **Contents:**
 

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -457,7 +457,7 @@ export async function openInterlinearizerFromScriptureEditor(
   // briefly reports zero tabs, and a non-waiting `count()` would misread that as "no editor".
   // `.first()` on the whole `.or()`: when both the editor and Home tabs are present the union
   // resolves to two elements, which would trip strict mode on this visibility assertion.
-  await expect(editorTab.or(homeTab).first()).toBeVisible({ timeout: 30_000 });
+  await expect(editorTab.or(homeTab).first()).toBeVisible({ timeout: 45_000 });
 
   // If the layout came up without a Scripture Editor (single-tab Home layout), open the project
   // from Home so the editor (and its ≡ menu) exists before we try to focus it.

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -7,6 +7,7 @@ import {
   Locator,
   Page,
 } from '@playwright/test';
+import escapeStringRegexp from 'escape-string-regexp';
 import fs from 'fs';
 import { createRequire } from 'module';
 import os from 'os';
@@ -446,7 +447,7 @@ export async function openInterlinearizerFromScriptureEditor(
   // A Scripture Editor tab is titled by the project short name once a project is loaded (e.g.
   // "WEB (Editable)"), and "Scripture Editor" only when no project is loaded. Escape projectName so
   // a short name with regex metacharacters can't corrupt the pattern.
-  const escapedProjectName = escapeRegExp(projectName);
+  const escapedProjectName = escapeStringRegexp(projectName);
   const editorTab = page
     .locator('.dock-tab', { hasText: new RegExp(`^(Scripture Editor|${escapedProjectName})\\b`) })
     .first();
@@ -471,8 +472,9 @@ export async function openInterlinearizerFromScriptureEditor(
 
   // The Scripture Editor renders its own toolbar inside its iframe. Click the ≡ ("Project") button.
   const editorFrame = page
-    .frameLocator(`iframe[title*="Scripture Editor" i], iframe[title^="${projectName}"]`)
-    .first();
+    .locator(`iframe[title*="Scripture Editor" i], iframe[title^="${projectName}"]`)
+    .first()
+    .contentFrame();
   await editorFrame.locator("button[aria-label='Project']").first().click();
 
   // Click the "Open Interlinearizer for this Project" item contributed by this extension.
@@ -530,14 +532,16 @@ function interlinearizerTabLocator(page: Page): Locator {
 }
 
 /**
- * Escape a literal string so it can be embedded in a `RegExp` without its metacharacters being
- * interpreted (e.g. a project short name containing `.` or `(`).
+ * Wait for Platform.Bible and the interlinearizer extension to finish starting up. Combines
+ * {@link waitForAppReady} and {@link waitForInterlinearizerReady}.
  *
- * @param literal The raw string to escape.
- * @returns The string with all regex metacharacters backslash-escaped.
+ * @param page The Playwright `Page` for the Platform.Bible renderer window.
+ * @returns Resolves when `interlinearizer.openForWebView` is listed in `rpc.discover`.
+ * @throws If the app or extension do not finish starting up within their default timeouts.
  */
-function escapeRegExp(literal: string): string {
-  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+export async function waitForAppAndInterlinearizerReady(page: Page): Promise<void> {
+  await waitForAppReady(page);
+  await waitForInterlinearizerReady();
 }
 
 /**

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -115,6 +115,9 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
       '--extensions',
       extensionDist,
       `--remote-debugging-port=${CDP_PORT}`,
+      // GitHub-hosted Linux runners don't ship a root-owned setuid chrome-sandbox binary, so
+      // Electron's SUID sandbox helper aborts on launch. Skip the OS sandbox on Linux.
+      ...(process.platform === 'linux' ? ['--no-sandbox'] : []),
     ],
     {
       cwd: coreDir,
@@ -130,11 +133,26 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
   if (appProcess.pid) fs.writeFileSync(CDP_PID_FILE, String(appProcess.pid));
 
   console.log(`Waiting for PAPI WebSocket on port ${WEBSOCKET_PORT}...`);
+  /**
+   * Rejects the moment {@link appProcess} exits, so a startup crash (e.g. a sandbox
+   * misconfiguration) fails setup immediately instead of only surfacing after the full
+   * {@link APP_READY_TIMEOUT} port-wait below elapses.
+   */
+  const earlyExit = new Promise<never>((_resolve, reject) => {
+    appProcess.once('exit', (code, signal) => {
+      reject(
+        new Error(
+          `Launched Platform.Bible (CDP) process exited early (code=${code}, signal=${signal}) ` +
+            'before its WebSocket port came up.',
+        ),
+      );
+    });
+  });
   try {
-    await waitForPort(WEBSOCKET_PORT, APP_READY_TIMEOUT);
+    await Promise.race([waitForPort(WEBSOCKET_PORT, APP_READY_TIMEOUT), earlyExit]);
   } catch (error) {
     // The app never came up. Echo its captured output so the failure cause is in the CI log itself,
-    // not just buried in the uploaded artifact, then re-throw the original timeout.
+    // not just buried in the uploaded artifact, then re-throw the original error.
     dumpAppLog();
     throw error;
   }

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -220,7 +220,7 @@ export async function bootstrapRendererDevServer(): Promise<void> {
     }
 
     console.log(`Waiting for renderer dev server on port ${RENDERER_PORT}...`);
-    await waitForPort(RENDERER_PORT, 60_000);
+    await waitForPort(RENDERER_PORT, 90_000);
     console.log(
       `Port ${RENDERER_PORT} is accepting connections. Waiting for webpack compilation...`,
     );

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -220,7 +220,7 @@ export async function bootstrapRendererDevServer(): Promise<void> {
     }
 
     console.log(`Waiting for renderer dev server on port ${RENDERER_PORT}...`);
-    await waitForPort(RENDERER_PORT, 90_000);
+    await waitForPort(RENDERER_PORT, 60_000);
     console.log(
       `Port ${RENDERER_PORT} is accepting connections. Waiting for webpack compilation...`,
     );

--- a/e2e-tests/global-teardown-cdp.ts
+++ b/e2e-tests/global-teardown-cdp.ts
@@ -1,49 +1,9 @@
 // Teardown for the self-launching CDP (feature-test) config.
 import type { FullConfig } from '@playwright/test';
-import { execFileSync } from 'child_process';
 import fs from 'fs';
 import { CDP_PID_FILE, CDP_USER_DATA_FILE } from './global-setup-cdp';
 import globalTeardown from './global-teardown';
-
-/**
- * Forcibly kill the launched app and all of its children, cross-platform.
- *
- * Electron spawns a tree of processes (main, renderer, GPU, utility). Leaving any alive holds the
- * PAPI WebSocket port and poisons the next run's fast-fail port check, so we must kill the whole
- * tree, not just the top process.
- *
- * - On Windows there is no process group and `process.kill(-pid)` is meaningless, so shell out to
- *   `taskkill /T /F`, which terminates the process and its entire descendant tree.
- * - Elsewhere the app was spawned `detached`, so it is its own process-group leader: signal the
- *   negative PID to SIGKILL the whole group in one call, falling back to the bare PID if the group
- *   is already gone.
- *
- * @param pid PID of the detached app process recorded by {@link globalSetupCdp}.
- * @returns `true` if a kill was issued, `false` if the process was already gone.
- */
-function killAppTree(pid: number): boolean {
-  if (process.platform === 'win32') {
-    try {
-      execFileSync('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' });
-      return true;
-    } catch {
-      // taskkill exits non-zero when the process is already gone — nothing left to kill.
-      return false;
-    }
-  }
-  try {
-    process.kill(-pid, 'SIGKILL');
-    return true;
-  } catch {
-    try {
-      process.kill(pid, 'SIGKILL');
-      return true;
-    } catch {
-      // Already stopped
-      return false;
-    }
-  }
-}
+import { killProcessTree } from './process-utils';
 
 /**
  * Playwright global teardown for the CDP config. Kills the Electron instance launched by
@@ -66,7 +26,7 @@ export default async function globalTeardownCdp(config: FullConfig): Promise<voi
       console.warn(`Invalid PID in ${CDP_PID_FILE}, skipping app kill`);
     } else {
       console.log(`Stopping self-launched Platform.Bible (CDP) app (PID: ${pid})...`);
-      appKilled = killAppTree(pid);
+      appKilled = killProcessTree(pid, 'SIGKILL');
     }
     fs.unlinkSync(CDP_PID_FILE);
   }

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -3,6 +3,7 @@ import type { FullConfig } from '@playwright/test';
 import { execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { killProcessTree } from './process-utils';
 
 /**
  * Playwright global teardown. Runs once after all test workers have finished.
@@ -28,15 +29,7 @@ export default async function globalTeardown(_config: FullConfig): Promise<void>
       fs.unlinkSync(pidFile);
     } else {
       console.log(`Stopping renderer dev server (PID: ${pid})...`);
-      try {
-        process.kill(-pid, 'SIGTERM');
-      } catch {
-        try {
-          process.kill(pid, 'SIGTERM');
-        } catch {
-          // Already stopped
-        }
-      }
+      killProcessTree(pid, 'SIGTERM');
       fs.unlinkSync(pidFile);
     }
   }

--- a/e2e-tests/process-utils.ts
+++ b/e2e-tests/process-utils.ts
@@ -1,0 +1,47 @@
+// Cross-platform process-tree termination, shared by global-teardown.ts and global-teardown-cdp.ts.
+import { execFileSync } from 'child_process';
+
+/**
+ * Forcibly kill a process and all of its descendants, cross-platform.
+ *
+ * Both the renderer dev server (`npm run start:renderer`, spawned via a shell) and the
+ * self-launched Electron app spawn a tree of child processes (webpack workers;
+ * main/renderer/GPU/utility). Killing only the top PID leaves the children running, which for the
+ * dev server means orphaned webpack workers and for Electron means a held PAPI WebSocket port that
+ * poisons the next run's fast-fail port check.
+ *
+ * - On Windows there is no process group and `process.kill(-pid)` is meaningless, so shell out to
+ *   `taskkill /T /F`, which terminates the process and its entire descendant tree. `taskkill`
+ *   always force-kills (no graceful-signal equivalent), so `signal` is ignored on this branch.
+ * - Elsewhere the target was spawned `detached`, so it is its own process-group leader: signal the
+ *   negative PID to signal the whole group in one call, falling back to the bare PID if the group
+ *   is already gone.
+ *
+ * @param pid PID of the detached process to kill.
+ * @param signal POSIX signal to send when not on Windows (ignored on Windows, which always
+ *   force-kills). Defaults to `'SIGTERM'`.
+ * @returns `true` if a kill was issued, `false` if the process was already gone.
+ */
+export function killProcessTree(pid: number, signal: NodeJS.Signals = 'SIGTERM'): boolean {
+  if (process.platform === 'win32') {
+    try {
+      execFileSync('taskkill', ['/pid', String(pid), '/T', '/F'], { stdio: 'ignore' });
+      return true;
+    } catch {
+      // taskkill exits non-zero when the process is already gone — nothing left to kill.
+      return false;
+    }
+  }
+  try {
+    process.kill(-pid, signal);
+    return true;
+  } catch {
+    try {
+      process.kill(pid, signal);
+      return true;
+    } catch {
+      // Already stopped
+      return false;
+    }
+  }
+}

--- a/e2e-tests/tests/_example/example-interlinearizer-feature.spec.ts
+++ b/e2e-tests/tests/_example/example-interlinearizer-feature.spec.ts
@@ -14,7 +14,7 @@
  * This file is excluded from test runs — it's documentation only.
  */
 import { test, expect } from '../../fixtures/cdp.fixture';
-import { waitForAppReady, waitForInterlinearizerReady } from '../../fixtures/helpers';
+import { waitForAppAndInterlinearizerReady } from '../../fixtures/helpers';
 
 /**
  * Filter out expected/benign console errors from a list of captured error messages.
@@ -34,8 +34,7 @@ function filterConsoleErrors(errors: string[]): string[] {
 
 test.describe('Example: Open Interlinearizer via menu', () => {
   test('should open the interlinearizer WebView via menu', async ({ mainPage }) => {
-    await waitForAppReady(mainPage);
-    await waitForInterlinearizerReady();
+    await waitForAppAndInterlinearizerReady(mainPage);
 
     // Step 1: Click the top-level menu that contains the interlinearizer entry
     const menuTrigger = mainPage.getByRole('menuitem', { name: /Tools/i });
@@ -51,8 +50,7 @@ test.describe('Example: Open Interlinearizer via menu', () => {
   });
 
   test('should render without critical console errors', async ({ mainPage }) => {
-    await waitForAppReady(mainPage);
-    await waitForInterlinearizerReady();
+    await waitForAppAndInterlinearizerReady(mainPage);
 
     const consoleErrors: string[] = [];
     mainPage.on('console', (msg) => {

--- a/e2e-tests/tests/features/draft-persistence.spec.ts
+++ b/e2e-tests/tests/features/draft-persistence.spec.ts
@@ -5,8 +5,7 @@ import {
   ensureInterlinearizerOpenOnWeb,
   getInterlinearizerFrame,
   navigateToScriptureRef,
-  waitForAppReady,
-  waitForInterlinearizerReady,
+  waitForAppAndInterlinearizerReady,
   wipeDraft,
 } from '../../fixtures/helpers';
 
@@ -17,8 +16,7 @@ test.describe('Draft persistence', () => {
     // Two full open cycles (plus first-use project creation and book loading on a cold instance)
     // legitimately exceed the default 120 s budget.
     test.slow();
-    await waitForAppReady(mainPage);
-    await waitForInterlinearizerReady();
+    await waitForAppAndInterlinearizerReady(mainPage);
     await ensureInterlinearizerOpenOnWeb(mainPage);
     await ensureE2eProjectActive(mainPage);
     await navigateToScriptureRef(mainPage, 'GEN 1:1');

--- a/e2e-tests/tests/features/gloss-roundtrip.spec.ts
+++ b/e2e-tests/tests/features/gloss-roundtrip.spec.ts
@@ -4,15 +4,13 @@ import {
   ensureInterlinearizerOpenOnWeb,
   getInterlinearizerFrame,
   navigateToScriptureRef,
-  waitForAppReady,
-  waitForInterlinearizerReady,
+  waitForAppAndInterlinearizerReady,
   wipeDraft,
 } from '../../fixtures/helpers';
 
 test.describe('Gloss round-trip', () => {
   test('typing a gloss on a token renders it in the gloss field', async ({ mainPage }) => {
-    await waitForAppReady(mainPage);
-    await waitForInterlinearizerReady();
+    await waitForAppAndInterlinearizerReady(mainPage);
     await ensureInterlinearizerOpenOnWeb(mainPage);
     await ensureE2eProjectActive(mainPage);
     await navigateToScriptureRef(mainPage, 'GEN 1:1');

--- a/e2e-tests/tests/features/project-modals.spec.ts
+++ b/e2e-tests/tests/features/project-modals.spec.ts
@@ -3,8 +3,7 @@ import {
   ensureInterlinearizerOpenOnWeb,
   getInterlinearizerFrame,
   openInterlinearizerProjectMenu,
-  waitForAppReady,
-  waitForInterlinearizerReady,
+  waitForAppAndInterlinearizerReady,
 } from '../../fixtures/helpers';
 
 /**
@@ -36,15 +35,14 @@ test.describe('Project modals cancel tour', () => {
     test(`the ${modal.name} modal opens from the Project menu and cancels cleanly`, async ({
       mainPage,
     }) => {
-      await waitForAppReady(mainPage);
-      await waitForInterlinearizerReady();
+      await waitForAppAndInterlinearizerReady(mainPage);
       await ensureInterlinearizerOpenOnWeb(mainPage);
 
       const frame = await openInterlinearizerProjectMenu(mainPage);
       await frame.getByRole('menuitem', { name: modal.menuItem }).first().click();
 
       const modalTitle = frame.locator(modal.titleSelector);
-      await expect(modalTitle).toBeVisible({ timeout: 10_000 });
+      await expect(modalTitle).toBeVisible({ timeout: 5_000 });
 
       await frame.locator('dialog').getByRole('button', { name: 'Cancel' }).click();
       await expect(modalTitle).not.toBeVisible({ timeout: 5_000 });

--- a/e2e-tests/tests/smoke/extension-launch.spec.ts
+++ b/e2e-tests/tests/smoke/extension-launch.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '../../fixtures/app.fixture';
-import { waitForAppReady, waitForInterlinearizerReady } from '../../fixtures/helpers';
+import { waitForAppAndInterlinearizerReady, waitForAppReady } from '../../fixtures/helpers';
 
 test.describe('Launch app and register Interlinearizer', () => {
   test('should launch Platform.Bible and create at least one window', async ({ electronApp }) => {
@@ -19,7 +19,6 @@ test.describe('Launch app and register Interlinearizer', () => {
   });
 
   test('should register Interlinearizer PAPI commands', async ({ mainPage }) => {
-    await waitForAppReady(mainPage);
-    await waitForInterlinearizerReady();
+    await waitForAppAndInterlinearizerReady(mainPage);
   });
 });

--- a/e2e-tests/tests/smoke/open-interlinearizer.spec.ts
+++ b/e2e-tests/tests/smoke/open-interlinearizer.spec.ts
@@ -1,14 +1,12 @@
 import { expect, test } from '../../fixtures/app.fixture';
 import {
   openInterlinearizerFromScriptureEditor,
-  waitForAppReady,
-  waitForInterlinearizerReady,
+  waitForAppAndInterlinearizerReady,
 } from '../../fixtures/helpers';
 
 test.describe('Open Interlinearizer', () => {
   test('should open the interlinearizer and see its menus', async ({ mainPage }) => {
-    await waitForAppReady(mainPage);
-    await waitForInterlinearizerReady();
+    await waitForAppAndInterlinearizerReady(mainPage);
 
     await openInterlinearizerFromScriptureEditor(mainPage);
 


### PR DESCRIPTION
Suggested modification to #151 

## Devin review

https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/160

### Devin's AI analysis
This PR improves the E2E test infrastructure for cross-platform reliability (especially Windows support in CI) and developer ergonomics:

- Extracts killProcessTree into a shared process-utils.ts — previously duplicated/inlined in both teardown files, now parameterized by signal.
- Improves CDP app launch resilience — adds --no-sandbox on Linux CI and an early-exit race so a startup crash fails immediately rather than waiting for the full port timeout.
- Adds waitForAppAndInterlinearizerReady convenience helper, replacing the two-call pattern across all test files. Also switches from a hand-rolled escapeRegExp to the escape-string-regexp package and updates the iframe locator API.
- Minor CI, .gitignore, and README housekeeping reflecting that Windows now runs the full suite.

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/160)
<!-- Reviewable:end -->
