### PR TITLE
Update scroll-group hook stubs for the new sourceProjectId tuple element

### DIFF
--- a/src/__tests__/components/InterlinearNavContext.test.tsx
+++ b/src/__tests__/components/InterlinearNavContext.test.tsx
@@ -37,7 +37,7 @@ function renderNav(hook: () => ScrollGroupTuple) {
  */
 function renderNavMutable(initial: SerializedVerseRef) {
   let current = initial;
-  const hook = (): ScrollGroupTuple => [current, () => {}, undefined, () => {}];
+  const hook = (): ScrollGroupTuple => [current, () => {}, undefined, () => {}, undefined];
   const wrapper = ({ children }: { children: ReactNode }) => (
     <InterlinearNavProvider useWebViewScrollGroupScrRef={hook}>{children}</InterlinearNavProvider>
   );

--- a/src/__tests__/components/Interlinearizer.test.tsx
+++ b/src/__tests__/components/Interlinearizer.test.tsx
@@ -11,7 +11,7 @@ import Interlinearizer from '../../components/Interlinearizer';
 import { InterlinearNavProvider } from '../../components/InterlinearNavContext';
 import type { SegmentDisplayMode } from '../../components/SegmentView';
 import { RECENTER_FADE_MS } from '../../components/recenter-fade';
-import { defaultScrRef, GEN_1_1_BOOK } from '../test-helpers';
+import { defaultScrRef, GEN_1_1_BOOK, type ScrollGroupTuple } from '../test-helpers';
 import { allFalseViewOptions } from './test-helpers';
 
 jest.mock('lucide-react', () => ({
@@ -366,12 +366,13 @@ const GEN_SUPERSCRIPTION_BOOK: Book = {
  * @returns The element wrapped in a nav provider.
  */
 function withNav(ui: ReactNode, navigate: (r: SerializedVerseRef) => void = () => {}): ReactNode {
-  const scrollGroupHook = (): [
-    SerializedVerseRef,
-    (r: SerializedVerseRef) => void,
-    number | undefined,
-    (id: number | undefined) => void,
-  ] => [defaultScrRef, navigate, undefined, () => {}];
+  const scrollGroupHook = (): ScrollGroupTuple => [
+    defaultScrRef,
+    navigate,
+    undefined,
+    () => {},
+    undefined,
+  ];
   return (
     <InterlinearNavProvider useWebViewScrollGroupScrRef={scrollGroupHook}>
       {ui}

--- a/src/__tests__/components/InterlinearizerLoader.test.tsx
+++ b/src/__tests__/components/InterlinearizerLoader.test.tsx
@@ -16,7 +16,12 @@ import useOptimisticBooleanSetting from '../../hooks/useOptimisticBooleanSetting
 import { emptyAnalysis, emptyDraft } from '../../types/empty-factories';
 import type { PhraseMode } from '../../types/phrase-mode';
 import type { ViewOptions } from '../../types/view-options';
-import { GEN_1_1_BOOK, makeScrollGroupHook, makeWebViewState } from '../test-helpers';
+import {
+  GEN_1_1_BOOK,
+  makeScrollGroupHook,
+  makeWebViewState,
+  type ScrollGroupTuple,
+} from '../test-helpers';
 
 jest.mock('../../hooks/useInterlinearizerBookData');
 jest.mock('../../hooks/useOptimisticBooleanSetting');
@@ -1413,17 +1418,9 @@ describe('InterlinearizerLoader', () => {
      */
     function makeMutableScrollGroupHook(
       initial: SerializedVerseRef,
-    ): [
-      () => [SerializedVerseRef, () => void, undefined, () => void],
-      (n: SerializedVerseRef) => void,
-    ] {
+    ): [() => ScrollGroupTuple, (n: SerializedVerseRef) => void] {
       let current = initial;
-      const hook = (): [SerializedVerseRef, () => void, undefined, () => void] => [
-        current,
-        () => {},
-        undefined,
-        () => {},
-      ];
+      const hook = (): ScrollGroupTuple => [current, () => {}, undefined, () => {}, undefined];
       return [
         hook,
         (next) => {

--- a/src/__tests__/interlinearizer.web-view.test.tsx
+++ b/src/__tests__/interlinearizer.web-view.test.tsx
@@ -5,7 +5,7 @@
 import type { WebViewProps } from '@papi/core';
 import type { SerializedVerseRef } from '@sillsdev/scripture';
 import { render, screen } from '@testing-library/react';
-import { defaultScrRef } from './test-helpers';
+import { defaultScrRef, type ScrollGroupTuple } from './test-helpers';
 
 jest.mock('../components/InterlinearizerLoader', () => ({
   __esModule: true,
@@ -37,12 +37,13 @@ function makeProps(projectId?: string, scrRef: SerializedVerseRef = defaultScrRe
       () => {},
       () => {},
     ],
-    useWebViewScrollGroupScrRef: (): [
-      SerializedVerseRef,
-      (r: SerializedVerseRef) => void,
-      number | undefined,
-      (id: number | undefined) => void,
-    ] => [scrRef, () => {}, undefined, () => {}],
+    useWebViewScrollGroupScrRef: (): ScrollGroupTuple => [
+      scrRef,
+      () => {},
+      undefined,
+      () => {},
+      undefined,
+    ],
     updateWebViewDefinition: () => true,
   };
 }

--- a/src/__tests__/test-helpers.ts
+++ b/src/__tests__/test-helpers.ts
@@ -1,6 +1,6 @@
 /** @file Shared test helpers for unit and component tests. */
 import type { SerializedVerseRef } from '@sillsdev/scripture';
-import type { ExecutionActivationContext } from '@papi/core';
+import type { ExecutionActivationContext, UseWebViewScrollGroupScrRefHook } from '@papi/core';
 import type { Book, InterlinearProject, PhraseAnalysisLink, Token } from 'interlinearizer';
 import { UnsubscriberAsyncList } from 'platform-bible-utils';
 import type { PhraseStripContextValue } from '../components/PhraseStripContext';
@@ -94,13 +94,12 @@ export function makePhraseStripContext(
 /** Genesis 1:1 serialized verse ref — shared across tests that need a default scroll position. */
 export const defaultScrRef: SerializedVerseRef = { book: 'GEN', chapterNum: 1, verseNum: 1 };
 
-/** Tuple shape returned by the PAPI scroll-group hook (`useWebViewScrollGroupScrRef`). */
-export type ScrollGroupTuple = [
-  SerializedVerseRef,
-  (r: SerializedVerseRef) => void,
-  number | undefined,
-  (id: number | undefined) => void,
-];
+/**
+ * Tuple shape returned by the PAPI scroll-group hook (`useWebViewScrollGroupScrRef`). Aliased from
+ * the platform hook's own return type so it tracks the tuple's arity (e.g. the trailing
+ * `sourceProjectId` added by the host) rather than restating — and drifting from — it.
+ */
+export type ScrollGroupTuple = ReturnType<UseWebViewScrollGroupScrRefHook>;
 
 /**
  * Builds a `useWebViewScrollGroupScrRef` host-hook stub returning the given tuple parts. Every
@@ -110,6 +109,7 @@ export type ScrollGroupTuple = [
  * @param setScrRef - The reference setter; defaults to a no-op.
  * @param scrollGroupId - The active scroll-group id; defaults to `undefined` (unlinked).
  * @param setScrollGroupId - The scroll-group setter; defaults to a no-op.
+ * @param sourceProjectId - The scroll group's source project id; defaults to `undefined`.
  * @returns A hook returning the assembled tuple.
  */
 export function makeScrollGroupHook(
@@ -117,8 +117,9 @@ export function makeScrollGroupHook(
   setScrRef: (r: SerializedVerseRef) => void = () => {},
   scrollGroupId: number | undefined = undefined,
   setScrollGroupId: (id: number | undefined) => void = () => {},
+  sourceProjectId: string | undefined = undefined,
 ): () => ScrollGroupTuple {
-  return () => [ref, setScrRef, scrollGroupId, setScrollGroupId];
+  return () => [ref, setScrRef, scrollGroupId, setScrollGroupId, sourceProjectId];
 }
 
 /** Pre-built Book with one GEN 1:1 segment and a single word token. */


### PR DESCRIPTION
## What

`paranext-core` added a trailing `sourceProjectId` element to
`UseWebViewScrollGroupScrRefHook`, so it now returns a 5-element tuple:

```ts
() => [scrRef, setScrRef, scrollGroupId, setScrollGroupId, sourceProjectId]
```

Our test stubs still constructed the old 4-element tuple, so `tsc --noEmit`
(via `npm run lint`) fails against current `@papi/core` with
`Source has 4 element(s) but target requires 5`.

This updates the stubs to match. **No production code changes** —
`InterlinearNavContext` destructures only the first four elements, so it was
already compatible; only the test doubles that *build* the tuple needed the
extra element.

## Changes

- `test-helpers.ts`: `ScrollGroupTuple` is now aliased from
  `ReturnType<UseWebViewScrollGroupScrRefHook>` instead of restating the tuple
  shape, so it tracks the platform hook's arity and can't drift again;
  `makeScrollGroupHook` gained a `sourceProjectId` param defaulting to
  `undefined`.
- Three tests that inlined their own 4-element tuple type
  (`Interlinearizer`, `InterlinearizerLoader`, `interlinearizer.web-view`) now
  use the shared `ScrollGroupTuple` alias plus a trailing `undefined` value.
- `InterlinearNavContext.test.tsx`: one inline stub got its fifth element.

## Why separate from the feature work

`main` itself fails to type-check against the current PAPI types, independent of
any feature branch — this restores `main` to green on its own.

## Verification

- `npm run lint` (eslint + stylelint + `tsc --noEmit`) — pass
- `npm test` — 1284 passing
- `npm run test:coverage` — 100%
`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/162)
<!-- Reviewable:end -->
