### PR TITLE
Fix stale setScrRef refs

### DIFF
--- a/src/__tests__/components/Interlinearizer.test.tsx
+++ b/src/__tests__/components/Interlinearizer.test.tsx
@@ -356,9 +356,9 @@ const GEN_SUPERSCRIPTION_BOOK: Book = {
 
 /**
  * Wraps an `<Interlinearizer>` element in an {@link InterlinearNavProvider} so the component's
- * `useInterlinearNav` call resolves. `Interlinearizer` now writes the reference through the
- * context's `navigate` (which calls the scroll-group hook's setter), so navigation assertions hang
- * off the `navigate` spy supplied here rather than a `setScrRef` prop.
+ * `useInterlinearNav` call resolves. `Interlinearizer` writes the reference through the context's
+ * `navigate` (which calls the scroll-group hook's setter), so navigation assertions hang off the
+ * `navigate` spy supplied here.
  *
  * @param ui - The `<Interlinearizer>` element to wrap.
  * @param navigate - Spy wired as the scroll-group hook's setter; receives the reference each
@@ -477,7 +477,7 @@ describe('Interlinearizer', () => {
     expect(screen.getAllByTestId('segment-view')).toHaveLength(2);
   });
 
-  it('calls setScrRef with the segment ref when a segment fires onSelect', () => {
+  it('calls navigate with the segment ref when a segment fires onSelect', () => {
     const mockNavigate = jest.fn();
     renderInterlinearizer({ book: GEN_1_MULTI_BOOK, navigate: mockNavigate });
 
@@ -517,7 +517,7 @@ describe('Interlinearizer', () => {
     expect(allElements[0]).toBe(continuousView);
   });
 
-  it('calls setScrRef with the segment ref when a token is clicked', () => {
+  it('calls navigate with the segment ref when a token is clicked', () => {
     const mockNavigate = jest.fn();
     renderInterlinearizer({
       book: GEN_1_MULTI_BOOK,
@@ -664,7 +664,7 @@ describe('Interlinearizer', () => {
     // During an external book change scrRef names the new book before its data loads, so the
     // mounted book (and its focused token) still belong to the previous book. The echo-back effect
     // must not fire that stale book's verse back as scrRef. Here the mounted book is GEN but scrRef
-    // names EXO, so a GEN focus move must not call setScrRef.
+    // names EXO, so a GEN focus move must not call navigate.
     const mockNavigate = jest.fn();
     renderInterlinearizer({
       book: GEN_1_MULTI_BOOK,

--- a/src/__tests__/components/InterlinearizerLoader.test.tsx
+++ b/src/__tests__/components/InterlinearizerLoader.test.tsx
@@ -151,7 +151,6 @@ type CapturedInterlinearizerProps = {
   book: Book;
   continuousScroll: boolean;
   scrRef: SerializedVerseRef;
-  setScrRef: (newScrRef: SerializedVerseRef) => void;
   analysisLanguage: string;
   initialAnalysis?: TextAnalysis;
   onSaveAnalysis?: (analysis: TextAnalysis) => void;


### PR DESCRIPTION
Left alone other legitimate occurrences.

Devin: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/163

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/163)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test descriptions and supporting comments to reflect the current navigation terminology.
  * Removed an obsolete navigation property from test-only component props.
  * No test behavior or assertions were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->