### PR TITLE
Bypass paranext-core first-run wizard overlay in e2e tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@ temp-build
 # Playwright output
 e2e-tests/.cdp-*
 e2e-tests/.dev-*
+e2e-tests/.e2e-settings-backup
 e2e-tests/playwright-report
 e2e-tests/test-results

--- a/e2e-tests/fixtures/app.fixture.ts
+++ b/e2e-tests/fixtures/app.fixture.ts
@@ -1,17 +1,16 @@
 // Adapted from paranext-core/e2e-tests/fixtures/app.fixture.ts
 import {
   test as base,
+  ConsoleMessage,
   ElectronApplication,
   Page,
   TestInfo,
-  ConsoleMessage,
 } from '@playwright/test';
 import {
   launchElectronWithExtension,
   preConfigureSettings,
-  teardownElectronApp,
-  ElectronAppContext,
   PROCESS_READY_TIMEOUT,
+  teardownElectronApp,
 } from './helpers';
 
 export { expect } from '@playwright/test';
@@ -37,21 +36,21 @@ export const test = base.extend<TestAppFixtures, WorkerAppFixtures>({
   electronApp: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
-      // Seed platform.firstRunComplete before launch so paranext-core's first-run wizard overlay
-      // does not gate the app on a fresh profile. The wizard is a full-screen modal Dialog that
-      // aria-hides the rest of the app and intercepts pointer events (blocking the toolbar/menu
-      // clicks these smoke tests drive), so tests must start past it. Restored after the app closes.
+      console.log('[startup] Configuring settings for worker-scoped app launch...');
       const restoreSettings = preConfigureSettings({ 'platform.firstRunComplete': true });
-      const ctx: ElectronAppContext = await launchElectronWithExtension();
-
-      await use(ctx.electronApp);
-
-      console.log('[teardown] Worker-scoped app teardown starting...');
-      await teardownElectronApp(ctx);
-      // Restore only after the app has fully closed so its shutdown writes cannot clobber the
-      // restored contents.
-      restoreSettings();
-      console.log('[teardown] Worker-scoped app teardown complete — worker will exit now');
+      try {
+        const ctx = await launchElectronWithExtension();
+        try {
+          await use(ctx.electronApp);
+        } finally {
+          console.log('[teardown] Worker-scoped app teardown starting...');
+          await teardownElectronApp(ctx);
+          console.log('[teardown] Worker-scoped app teardown complete');
+        }
+      } finally {
+        restoreSettings();
+        console.log('[teardown] Original settings restored — worker will exit now');
+      }
     },
     { scope: 'worker' },
   ],

--- a/e2e-tests/fixtures/app.fixture.ts
+++ b/e2e-tests/fixtures/app.fixture.ts
@@ -7,6 +7,7 @@ import {
   TestInfo,
 } from '@playwright/test';
 import {
+  E2E_SETTINGS_OVERRIDES,
   launchElectronWithExtension,
   preConfigureSettings,
   PROCESS_READY_TIMEOUT,
@@ -37,7 +38,7 @@ export const test = base.extend<TestAppFixtures, WorkerAppFixtures>({
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
       console.log('[startup] Configuring settings for worker-scoped app launch...');
-      const restoreSettings = preConfigureSettings({ 'platform.firstRunComplete': true });
+      const restoreSettings = preConfigureSettings(E2E_SETTINGS_OVERRIDES);
       try {
         const ctx = await launchElectronWithExtension();
         try {

--- a/e2e-tests/fixtures/app.fixture.ts
+++ b/e2e-tests/fixtures/app.fixture.ts
@@ -8,6 +8,7 @@ import {
 } from '@playwright/test';
 import {
   launchElectronWithExtension,
+  preConfigureSettings,
   teardownElectronApp,
   ElectronAppContext,
   PROCESS_READY_TIMEOUT,
@@ -36,12 +37,20 @@ export const test = base.extend<TestAppFixtures, WorkerAppFixtures>({
   electronApp: [
     // eslint-disable-next-line no-empty-pattern
     async ({}, use) => {
+      // Seed platform.firstRunComplete before launch so paranext-core's first-run wizard overlay
+      // does not gate the app on a fresh profile. The wizard is a full-screen modal Dialog that
+      // aria-hides the rest of the app and intercepts pointer events (blocking the toolbar/menu
+      // clicks these smoke tests drive), so tests must start past it. Restored after the app closes.
+      const restoreSettings = preConfigureSettings({ 'platform.firstRunComplete': true });
       const ctx: ElectronAppContext = await launchElectronWithExtension();
 
       await use(ctx.electronApp);
 
       console.log('[teardown] Worker-scoped app teardown starting...');
       await teardownElectronApp(ctx);
+      // Restore only after the app has fully closed so its shutdown writes cannot clobber the
+      // restored contents.
+      restoreSettings();
       console.log('[teardown] Worker-scoped app teardown complete — worker will exit now');
     },
     { scope: 'worker' },

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -42,6 +42,13 @@ const SMOKE_APP_LOG_FILE = path.join(__dirname, '..', '.smoke-app-startup.log');
 const PLATFORM_ABOUT_COMMAND = 'command:platform.about';
 
 /**
+ * Serialized PAPI request for `ProjectLookupService.getMetadataForAllProjects` (see
+ * `network-object.service.ts` `getNetworkObjectRequestType`). Mirrors paranext-core's helpers.
+ */
+const PROJECT_LOOKUP_GET_ALL_PROJECTS_METHOD =
+  'object:ProjectLookupService.getMetadataForAllProjects';
+
+/**
  * `rpc.discover` method names that appear once paranext-core's settings, menu-data, and theme
  * service hosts register their provider network objects — the signal that gates a resolved dock
  * (see {@link waitForServiceHostsRegistered}).
@@ -810,6 +817,41 @@ export async function waitForInterlinearizerReady(
 }
 
 /**
+ * Poll until `ProjectLookupService.getMetadataForAllProjects` returns at least one project.
+ *
+ * The bundled sample WEB project installs into the project root asynchronously, independently of
+ * dock/extension readiness — this closes that race explicitly instead of relying on a locator's own
+ * actionability timeout.
+ *
+ * @param timeoutMs Maximum time in milliseconds to poll before throwing.
+ * @returns Resolves once at least one project is registered.
+ * @throws {Error} If no project is registered within `timeoutMs` milliseconds.
+ */
+export async function waitForAtLeastOneProjectMetadata(timeoutMs = 60_000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    const remaining = timeoutMs - (Date.now() - start);
+    try {
+      const result = await sendPapiRequestOnce<unknown[]>(
+        PROJECT_LOOKUP_GET_ALL_PROJECTS_METHOD,
+        [],
+        DEFAULT_WEBSOCKET_PORT,
+        Math.min(10_000, Math.max(1_000, remaining)),
+      );
+      if (Array.isArray(result) && result.length > 0) return;
+    } catch {
+      /* Project lookup network object not registered yet; next poll. */
+    }
+    const sleepMs = Math.min(RPC_DISCOVER_POLL_INTERVAL_MS, timeoutMs - (Date.now() - start));
+    if (sleepMs <= 0) break;
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, sleepMs);
+    });
+  }
+  throw new Error(`No project metadata registered within ${timeoutMs}ms`);
+}
+
+/**
  * Open the Interlinearizer WebView from the Scripture Editor's top (≡) menu, ensuring the project
  * is loaded into the editor first. Prerequisite stage shared by all e2e tests that require the
  * Interlinearizer to be open.
@@ -892,6 +934,9 @@ export async function openInterlinearizerFromScriptureEditor(
       await homeTab.dispatchEvent('click');
     }
     const homeFrame = page.frameLocator('iframe[title="Home"]');
+    // The project row can still be installing even though the dock is ready; wait for it
+    // explicitly so a lost race fails clearly here, not as an opaque timeout on the click below.
+    await waitForAtLeastOneProjectMetadata();
     // Match the project's own row by its EXACT name (`:text-is()`), not a substring (`:has-text()`),
     // so a shorter project name can't select a row for a differently-named project that merely
     // contains it. The name is JSON-encoded before interpolation so a `"` in it can't break out of

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -150,6 +150,22 @@ export const DEV_APPDATA_SETTINGS_PATH = path.resolve(
 );
 
 /**
+ * Settings overrides seeded before every e2e launch, both tiers (see {@link backupAndSeedSettings}
+ * callers in fixtures/app.fixture.ts and global-setup-cdp.ts). Suppresses the first-run wizard
+ * overlay and forces Power interface mode.
+ *
+ * Power mode is a stand-in, not a permanent choice: paranext-core's Simple mode (the default)
+ * currently hides the Home/Editor columns' tab bars entirely (headless) and its Resources column
+ * ships default tabs a bare e2e profile can never resolve real titles for, which breaks both
+ * `.dock-tab` clicks and the strict cold-start readiness gate. Forcing Power mode sidesteps both
+ * until this suite adds real Simple-mode support.
+ */
+export const E2E_SETTINGS_OVERRIDES: Record<string, unknown> = {
+  'platform.firstRunComplete': true,
+  'platform.interfaceMode': 'power',
+};
+
+/**
  * File the pre-launch dev-appdata settings backup is written to (kept in `e2e-tests/`, alongside
  * the `.cdp-*` run-marker files). Shared by BOTH the smoke and CDP tiers rather than one file per
  * tier: there is only one `settings.json` to protect, and a single shared backup means a stale
@@ -807,9 +823,10 @@ export async function waitForInterlinearizerReady(
  * open the Interlinearizer directly instead of popping a project-picker dialog. The startup dock
  * layout varies, so this reaches that loaded state resiliently rather than assuming it:
  *
- * - A fresh core profile opens the default multi-tab layout with an empty "Scripture Editor" tab (no
- *   project loaded) and NO Home dock tab — the project is opened from Home (toolbar Home button,
- *   which is always present).
+ * - A fresh core profile has been seen opening either with an empty "Scripture Editor" tab and no
+ *   Home dock tab (older paranext-core), or directly to an already-open Home tab (current default)
+ *   — in both cases the project is opened via Home (the toolbar Home button, always present,
+ *   focuses the existing Home tab if one is already open rather than duplicating it).
  * - A warm CDP instance already has the editor open on a project (tab titled e.g. "WEB (Editable)").
  *
  * Steps:
@@ -846,14 +863,19 @@ export async function openInterlinearizerFromScriptureEditor(
   const anyEditorTab = page
     .locator('.dock-tab', { hasText: new RegExp(`^(Scripture Editor|${escapedProjectName})\\b`) })
     .first();
-  // The toolbar's "Home..." button (a ghost icon button wrapping lucide's HomeIcon). It opens Home
-  // regardless of dock layout — the default multi-tab layout has no Home dock tab. The svg is
-  // `aria-hidden`, so target the enclosing button by the icon class rather than by role/name.
+  // The Home dock tab, when one is already open (current default: a fresh profile opens directly to
+  // Home rather than an empty "Scripture Editor" tab — see the wait below).
+  const homeTab = page.locator('.dock-tab', { hasText: 'Home' }).first();
+  // The toolbar's "Home..." button (a ghost icon button wrapping lucide's HomeIcon). Opens Home when
+  // it is not already open as its own tab (see the branch below). The svg is `aria-hidden`, so target
+  // the enclosing button by the icon class rather than by role/name.
   const homeButton = page.locator('button:has(svg.lucide-house)').first();
 
   // Wait for the dock layout to mount before branching — a fresh profile briefly reports zero tabs,
-  // which a non-waiting `count()` would misread as "no editor".
-  await expect(anyEditorTab).toBeVisible({ timeout: 45_000 });
+  // which a non-waiting `count()` would misread as "no editor". Accept either an editor tab OR an
+  // already-open Home tab as evidence of a mounted dock: which one a fresh profile starts with has
+  // changed between paranext-core versions, and this helper works against either starting layout.
+  await expect(anyEditorTab.or(homeTab).first()).toBeVisible({ timeout: 45_000 });
 
   // Ensure the project is loaded into a Scripture Editor, not merely that some editor tab exists:
   // without a project-bearing editor, BCV navigation has no target (nav control stays disabled) and
@@ -861,7 +883,14 @@ export async function openInterlinearizerFromScriptureEditor(
   // loads it into the editor. Skipped when a project-titled editor tab is already present (warm CDP
   // instance).
   if ((await loadedEditorTab.count()) === 0) {
-    await homeButton.click();
+    // Home may already be open as its own dock tab (current default) rather than needing the toolbar
+    // button to open it (older default, still true for CDP's warm-but-project-less instance) — only
+    // click the button when Home isn't already open, rather than relying on a redundant click being a
+    // harmless no-op.
+    if ((await homeTab.count()) === 0) {
+      await homeButton.click();
+      await expect(homeTab).toBeVisible({ timeout: 10_000 });
+    }
     const homeFrame = page.frameLocator('iframe[title="Home"]');
     // Match the project's own row by its EXACT name (`:text-is()`), not a substring (`:has-text()`),
     // so a shorter project name can't select a row for a differently-named project that merely
@@ -877,7 +906,6 @@ export async function openInterlinearizerFromScriptureEditor(
     // its iframe intercepts pointer events, so the ≡-menu click below would land on Home. Dispatch
     // the close (not a real click, so an off-viewport tab on small CI viewports still closes), then
     // wait for the tab to leave the DOM.
-    const homeTab = page.locator('.dock-tab', { hasText: 'Home' }).first();
     await homeTab
       .locator('.dock-tab-close-btn')
       .dispatchEvent('click')
@@ -1111,9 +1139,13 @@ export async function ensureInterlinearizerOpenOnWeb(page: Page): Promise<void> 
   // Settle the dock layout before the non-retrying isVisible() branch below: the readiness helpers
   // only poll rpc.discover, not the DOM, so a not-yet-painted Interlinearizer tab would read as
   // "absent" and send us needlessly down the full open-from-editor flow. `.first()` on the whole
-  // `.or()` keeps the assertion out of strict mode when both tabs are present (per-operand `.first()`
-  // does not collapse the union).
-  const anchorTab = page.locator('.dock-tab', { hasText: /Scripture Editor|WEB/ }).first();
+  // `.or()` keeps the assertion out of strict mode when multiple tabs are present (per-operand
+  // `.first()` does not collapse the union). A fresh/shared instance may land on an already-open Home
+  // tab rather than a Scripture Editor/WEB tab — accept that too, since the fallback branch below
+  // (openInterlinearizerFromScriptureEditor) already knows how to open the project from Home.
+  const anchorTab = page
+    .locator('.dock-tab', { hasText: /^(Scripture Editor|WEB|Home)\b/ })
+    .first();
   await expect(interlinearizerTab.or(anchorTab).first()).toBeVisible({ timeout: 30_000 });
 
   if (await interlinearizerTab.isVisible()) {

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -154,11 +154,9 @@ export const DEV_APPDATA_SETTINGS_PATH = path.resolve(
  * callers in fixtures/app.fixture.ts and global-setup-cdp.ts). Suppresses the first-run wizard
  * overlay and forces Power interface mode.
  *
- * Power mode is a stand-in, not a permanent choice: paranext-core's Simple mode (the default)
- * currently hides the Home/Editor columns' tab bars entirely (headless) and its Resources column
- * ships default tabs a bare e2e profile can never resolve real titles for, which breaks both
- * `.dock-tab` clicks and the strict cold-start readiness gate. Forcing Power mode sidesteps both
- * until this suite adds real Simple-mode support.
+ * Forcing Power mode is a stopgap, not the end goal: paranext-core's Simple mode (the default)
+ * hides the dock tab bars this suite's `.dock-tab` locators and cold-start readiness gate depend
+ * on. The suite should eventually cover both modes rather than forcing Power mode for every test.
  */
 export const E2E_SETTINGS_OVERRIDES: Record<string, unknown> = {
   'platform.firstRunComplete': true,
@@ -167,11 +165,9 @@ export const E2E_SETTINGS_OVERRIDES: Record<string, unknown> = {
 
 /**
  * File the pre-launch dev-appdata settings backup is written to (kept in `e2e-tests/`, alongside
- * the `.cdp-*` run-marker files). Shared by BOTH the smoke and CDP tiers rather than one file per
- * tier: there is only one `settings.json` to protect, and a single shared backup means a stale
- * backup left by, say, a hard-killed CDP run is what the smoke tier's own self-heal (see
- * {@link backupAndSeedSettings}) recovers too — instead of the smoke tier mistaking the CDP tier's
- * already-seeded settings for the developer's true original.
+ * the `.cdp-*` run-marker files). Shared by BOTH the smoke and CDP tiers, not one file per tier:
+ * there is only one `settings.json` to protect, so a stale backup left by either tier's crashed run
+ * can be recovered by the other tier's own self-heal (see {@link backupAndSeedSettings}).
  */
 const SETTINGS_BACKUP_FILE = path.join(__dirname, '..', '.e2e-settings-backup');
 

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -13,7 +13,7 @@ import { createRequire } from 'module';
 import os from 'os';
 import path from 'path';
 import WebSocket from 'ws';
-import { killProcessTree } from '../process-utils';
+import { killProcessTree, removeDirWithRetry, waitForProcessExit } from '../process-utils';
 
 const DEFAULT_WEBSOCKET_PORT = 8876;
 const RPC_DISCOVER_POLL_INTERVAL_MS = 250;
@@ -150,41 +150,38 @@ export const DEV_APPDATA_SETTINGS_PATH = path.resolve(
 );
 
 /**
- * File the smoke tier's pre-launch dev-appdata settings backup is written to (kept alongside
- * {@link SMOKE_APP_LOG_FILE} in `e2e-tests/`), so a hard-killed worker process (CI timeout SIGKILL,
- * Ctrl+C) leaves a recoverable on-disk backup instead of losing the developer's original settings
- * with the process — mirrors the CDP tier's `.cdp-settings-backup`.
+ * File the pre-launch dev-appdata settings backup is written to (kept in `e2e-tests/`, alongside
+ * the `.cdp-*` run-marker files). Shared by BOTH the smoke and CDP tiers rather than one file per
+ * tier: there is only one `settings.json` to protect, and a single shared backup means a stale
+ * backup left by, say, a hard-killed CDP run is what the smoke tier's own self-heal (see
+ * {@link backupAndSeedSettings}) recovers too — instead of the smoke tier mistaking the CDP tier's
+ * already-seeded settings for the developer's true original.
  */
-const SMOKE_SETTINGS_BACKUP_FILE = path.join(__dirname, '..', '.smoke-settings-backup');
+const SETTINGS_BACKUP_FILE = path.join(__dirname, '..', '.e2e-settings-backup');
 
-/** Marker stored in a settings backup file when no settings file existed before seeding. */
+/** Marker stored in {@link SETTINGS_BACKUP_FILE} when no settings file existed before seeding. */
 const SETTINGS_ABSENT_SENTINEL = '__SETTINGS_ABSENT__';
 
 /**
- * Back up paranext-core's dev-appdata settings file to `backupFilePath` (recording
+ * Back up paranext-core's dev-appdata settings file to {@link SETTINGS_BACKUP_FILE} (recording
  * {@link SETTINGS_ABSENT_SENTINEL} if no file exists yet) and merge `overrides` into it. Must be
  * called BEFORE launching Electron so the app reads the overrides at startup.
  *
- * Self-heals a stale backup left by a prior hard-killed run (restoring it first), so the backup
- * always captures the true original settings, never an already-seeded file.
+ * Self-heals a stale backup left by a prior hard-killed run of EITHER tier (restoring it first), so
+ * the backup always captures the true original settings, never an already-seeded file.
  *
- * @param backupFilePath Path the pre-seed contents are backed up to, for
- *   {@link restoreBackedUpSettings} to restore later.
  * @param overrides Setting keys to merge into the file (e.g. `{ 'platform.firstRunComplete': true
  *   }`).
  * @returns Nothing.
  */
-export function backupAndSeedSettings(
-  backupFilePath: string,
-  overrides: Record<string, unknown>,
-): void {
-  restoreBackedUpSettings(backupFilePath);
+export function backupAndSeedSettings(overrides: Record<string, unknown>): void {
+  restoreBackedUpSettings();
 
   const settingsDir = path.dirname(DEV_APPDATA_SETTINGS_PATH);
   let existing: Record<string, unknown> = {};
   if (fs.existsSync(DEV_APPDATA_SETTINGS_PATH)) {
     const original = fs.readFileSync(DEV_APPDATA_SETTINGS_PATH, 'utf-8');
-    fs.writeFileSync(backupFilePath, original);
+    fs.writeFileSync(SETTINGS_BACKUP_FILE, original);
     try {
       const parsed: unknown = JSON.parse(original);
       // Preserve existing settings only when the file holds a JSON object; a corrupt or non-object
@@ -196,39 +193,38 @@ export function backupAndSeedSettings(
   } else {
     // Record absence so restoreBackedUpSettings deletes the file this seed creates rather than
     // leaving it behind.
-    fs.writeFileSync(backupFilePath, SETTINGS_ABSENT_SENTINEL);
+    fs.writeFileSync(SETTINGS_BACKUP_FILE, SETTINGS_ABSENT_SENTINEL);
   }
   fs.mkdirSync(settingsDir, { recursive: true });
   fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, JSON.stringify({ ...existing, ...overrides }));
 }
 
 /**
- * Undo {@link backupAndSeedSettings}: restore the dev-appdata settings file from `backupFilePath`
- * (or delete it if the backup marks that no settings file existed before seeding), then remove the
- * backup marker. A no-op when no backup exists at that path. Best-effort: guarded so a
- * settings-restore failure never throws.
+ * Undo {@link backupAndSeedSettings}: restore the dev-appdata settings file from
+ * {@link SETTINGS_BACKUP_FILE} (or delete it if the backup marks that no settings file existed
+ * before seeding), then remove the backup marker. A no-op when no backup exists. Best-effort:
+ * guarded so a settings-restore failure never throws.
  *
- * @param backupFilePath Path previously passed to {@link backupAndSeedSettings}.
  * @returns Nothing.
  */
-export function restoreBackedUpSettings(backupFilePath: string): void {
-  if (!fs.existsSync(backupFilePath)) return;
+export function restoreBackedUpSettings(): void {
+  if (!fs.existsSync(SETTINGS_BACKUP_FILE)) return;
   try {
-    const backup = fs.readFileSync(backupFilePath, 'utf-8');
+    const backup = fs.readFileSync(SETTINGS_BACKUP_FILE, 'utf-8');
     if (backup === SETTINGS_ABSENT_SENTINEL) fs.rmSync(DEV_APPDATA_SETTINGS_PATH, { force: true });
     else fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, backup);
-    fs.rmSync(backupFilePath, { force: true });
+    fs.rmSync(SETTINGS_BACKUP_FILE, { force: true });
   } catch (error) {
-    console.warn(`Could not restore dev-appdata settings from ${backupFilePath}: ${error}`);
+    console.warn(`Could not restore dev-appdata settings from ${SETTINGS_BACKUP_FILE}: ${error}`);
   }
 }
 
 /**
  * Pre-configure paranext-core's dev-appdata settings before launching the smoke tier's per-worker
- * Electron instance (e.g. suppressing the first-run wizard), backing up the original to
- * {@link SMOKE_SETTINGS_BACKUP_FILE} on disk rather than only in memory — so a hard-killed worker
- * process (CI timeout SIGKILL, Ctrl+C) leaves a recoverable backup instead of losing the
- * developer's original settings with the process.
+ * Electron instance (e.g. suppressing the first-run wizard), backing up the original to disk (see
+ * {@link backupAndSeedSettings}) rather than only in memory — so a hard-killed worker process (CI
+ * timeout SIGKILL, Ctrl+C) leaves a recoverable backup instead of losing the developer's original
+ * settings with the process.
  *
  * @param overrides Setting keys to merge into the file (e.g. `{ 'platform.firstRunComplete': true
  *   }`).
@@ -237,8 +233,8 @@ export function restoreBackedUpSettings(backupFilePath: string): void {
  *   not permanently replaced by test values.
  */
 export function preConfigureSettings(overrides: Record<string, unknown>): () => void {
-  backupAndSeedSettings(SMOKE_SETTINGS_BACKUP_FILE, overrides);
-  return () => restoreBackedUpSettings(SMOKE_SETTINGS_BACKUP_FILE);
+  backupAndSeedSettings(overrides);
+  return restoreBackedUpSettings;
 }
 
 /**
@@ -417,29 +413,12 @@ export async function teardownElectronApp(ctx: ElectronAppContext): Promise<void
     console.log('[teardown] Sending SIGKILL to process group...');
     if (electronProcess.pid) killProcessTree(electronProcess.pid, 'SIGKILL');
     console.log('[teardown] Waiting for appClosed after SIGKILL (up to 3s)...');
-    await Promise.race([
-      appClosed,
-      new Promise<void>((resolve) => {
-        setTimeout(resolve, 3_000);
-      }),
-    ]);
+    await waitForProcessExit(appClosed, 3_000);
     console.log('[teardown] Done waiting after SIGKILL');
   }
 
   console.log('[teardown] Cleaning up user data dir...');
-  try {
-    fs.rmSync(userDataDir, { recursive: true, force: true });
-  } catch {
-    console.warn('[teardown] First rmSync attempt failed — retrying in 3s...');
-    await new Promise<void>((resolve) => {
-      setTimeout(resolve, 3_000);
-    });
-    try {
-      fs.rmSync(userDataDir, { recursive: true, force: true });
-    } catch (e) {
-      console.warn(`[teardown] Could not remove ${userDataDir}: ${e}`);
-    }
-  }
+  await removeDirWithRetry(userDataDir, 'user data dir');
   console.log('[teardown] Complete');
 }
 

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -139,6 +139,53 @@ async function waitForWebSocketReady(port: number, timeout: number): Promise<voi
 }
 
 /**
+ * Path to paranext-core's shared dev-appdata settings file. In development mode Platform.Bible
+ * reads this file at startup to restore settings, so writing it before launching Electron is how
+ * E2E tests pre-configure settings (e.g. suppressing the first-run wizard). Resolved relative to
+ * the sibling `paranext-core` checkout the app is launched from.
+ */
+export const DEV_APPDATA_SETTINGS_PATH = path.resolve(
+  __dirname,
+  '../../../paranext-core/dev-appdata/data/settings.json',
+);
+
+/**
+ * Merge the given key-value pairs into paranext-core's dev-appdata settings file before launching
+ * the app, preserving any existing settings. Must be called BEFORE launching Electron so the app
+ * reads the overrides at startup.
+ *
+ * @param overrides Setting keys to merge into the file (e.g. `{ 'platform.firstRunComplete': true
+ *   }`).
+ * @returns A restore function that rewrites the file to its exact pre-call contents (or deletes it
+ *   if it did not exist). Call it AFTER the app has closed so the developer's saved settings are
+ *   not permanently replaced by test values.
+ */
+export function preConfigureSettings(overrides: Record<string, unknown>): () => void {
+  const settingsDir = path.dirname(DEV_APPDATA_SETTINGS_PATH);
+  let originalContents: string | undefined;
+  let existing: Record<string, unknown> = {};
+  if (fs.existsSync(DEV_APPDATA_SETTINGS_PATH)) {
+    originalContents = fs.readFileSync(DEV_APPDATA_SETTINGS_PATH, 'utf-8');
+    try {
+      const parsed: unknown = JSON.parse(originalContents);
+      // Preserve existing settings only when the file holds a JSON object; a corrupt or non-object
+      // file falls back to just the overrides.
+      if (parsed && typeof parsed === 'object') existing = { ...parsed };
+    } catch {
+      // Corrupt file — start fresh with only the overrides.
+    }
+  }
+  fs.mkdirSync(settingsDir, { recursive: true });
+  fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, JSON.stringify({ ...existing, ...overrides }));
+
+  return () => {
+    if (originalContents !== undefined)
+      fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, originalContents);
+    else fs.rmSync(DEV_APPDATA_SETTINGS_PATH, { force: true });
+  };
+}
+
+/**
  * Launch a fresh Electron instance (paranext-core) with the interlinearizer extension loaded via
  * `--extensions`.
  *

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -150,39 +150,95 @@ export const DEV_APPDATA_SETTINGS_PATH = path.resolve(
 );
 
 /**
- * Merge the given key-value pairs into paranext-core's dev-appdata settings file before launching
- * the app, preserving any existing settings. Must be called BEFORE launching Electron so the app
- * reads the overrides at startup.
+ * File the smoke tier's pre-launch dev-appdata settings backup is written to (kept alongside
+ * {@link SMOKE_APP_LOG_FILE} in `e2e-tests/`), so a hard-killed worker process (CI timeout SIGKILL,
+ * Ctrl+C) leaves a recoverable on-disk backup instead of losing the developer's original settings
+ * with the process — mirrors the CDP tier's `.cdp-settings-backup`.
+ */
+const SMOKE_SETTINGS_BACKUP_FILE = path.join(__dirname, '..', '.smoke-settings-backup');
+
+/** Marker stored in a settings backup file when no settings file existed before seeding. */
+const SETTINGS_ABSENT_SENTINEL = '__SETTINGS_ABSENT__';
+
+/**
+ * Back up paranext-core's dev-appdata settings file to `backupFilePath` (recording
+ * {@link SETTINGS_ABSENT_SENTINEL} if no file exists yet) and merge `overrides` into it. Must be
+ * called BEFORE launching Electron so the app reads the overrides at startup.
  *
+ * Self-heals a stale backup left by a prior hard-killed run (restoring it first), so the backup
+ * always captures the true original settings, never an already-seeded file.
+ *
+ * @param backupFilePath Path the pre-seed contents are backed up to, for
+ *   {@link restoreBackedUpSettings} to restore later.
  * @param overrides Setting keys to merge into the file (e.g. `{ 'platform.firstRunComplete': true
  *   }`).
- * @returns A restore function that rewrites the file to its exact pre-call contents (or deletes it
- *   if it did not exist). Call it AFTER the app has closed so the developer's saved settings are
- *   not permanently replaced by test values.
+ * @returns Nothing.
  */
-export function preConfigureSettings(overrides: Record<string, unknown>): () => void {
+export function backupAndSeedSettings(
+  backupFilePath: string,
+  overrides: Record<string, unknown>,
+): void {
+  restoreBackedUpSettings(backupFilePath);
+
   const settingsDir = path.dirname(DEV_APPDATA_SETTINGS_PATH);
-  let originalContents: string | undefined;
   let existing: Record<string, unknown> = {};
   if (fs.existsSync(DEV_APPDATA_SETTINGS_PATH)) {
-    originalContents = fs.readFileSync(DEV_APPDATA_SETTINGS_PATH, 'utf-8');
+    const original = fs.readFileSync(DEV_APPDATA_SETTINGS_PATH, 'utf-8');
+    fs.writeFileSync(backupFilePath, original);
     try {
-      const parsed: unknown = JSON.parse(originalContents);
+      const parsed: unknown = JSON.parse(original);
       // Preserve existing settings only when the file holds a JSON object; a corrupt or non-object
       // file falls back to just the overrides.
       if (parsed && typeof parsed === 'object') existing = { ...parsed };
     } catch {
-      // Corrupt file — start fresh with only the overrides.
+      // Corrupt file — overwrite with just the overrides.
     }
+  } else {
+    // Record absence so restoreBackedUpSettings deletes the file this seed creates rather than
+    // leaving it behind.
+    fs.writeFileSync(backupFilePath, SETTINGS_ABSENT_SENTINEL);
   }
   fs.mkdirSync(settingsDir, { recursive: true });
   fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, JSON.stringify({ ...existing, ...overrides }));
+}
 
-  return () => {
-    if (originalContents !== undefined)
-      fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, originalContents);
-    else fs.rmSync(DEV_APPDATA_SETTINGS_PATH, { force: true });
-  };
+/**
+ * Undo {@link backupAndSeedSettings}: restore the dev-appdata settings file from `backupFilePath`
+ * (or delete it if the backup marks that no settings file existed before seeding), then remove the
+ * backup marker. A no-op when no backup exists at that path. Best-effort: guarded so a
+ * settings-restore failure never throws.
+ *
+ * @param backupFilePath Path previously passed to {@link backupAndSeedSettings}.
+ * @returns Nothing.
+ */
+export function restoreBackedUpSettings(backupFilePath: string): void {
+  if (!fs.existsSync(backupFilePath)) return;
+  try {
+    const backup = fs.readFileSync(backupFilePath, 'utf-8');
+    if (backup === SETTINGS_ABSENT_SENTINEL) fs.rmSync(DEV_APPDATA_SETTINGS_PATH, { force: true });
+    else fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, backup);
+    fs.rmSync(backupFilePath, { force: true });
+  } catch (error) {
+    console.warn(`Could not restore dev-appdata settings from ${backupFilePath}: ${error}`);
+  }
+}
+
+/**
+ * Pre-configure paranext-core's dev-appdata settings before launching the smoke tier's per-worker
+ * Electron instance (e.g. suppressing the first-run wizard), backing up the original to
+ * {@link SMOKE_SETTINGS_BACKUP_FILE} on disk rather than only in memory — so a hard-killed worker
+ * process (CI timeout SIGKILL, Ctrl+C) leaves a recoverable backup instead of losing the
+ * developer's original settings with the process.
+ *
+ * @param overrides Setting keys to merge into the file (e.g. `{ 'platform.firstRunComplete': true
+ *   }`).
+ * @returns A restore function that puts the file back to its exact pre-call contents (or deletes it
+ *   if it did not exist). Call it AFTER the app has closed so the developer's saved settings are
+ *   not permanently replaced by test values.
+ */
+export function preConfigureSettings(overrides: Record<string, unknown>): () => void {
+  backupAndSeedSettings(SMOKE_SETTINGS_BACKUP_FILE, overrides);
+  return () => restoreBackedUpSettings(SMOKE_SETTINGS_BACKUP_FILE);
 }
 
 /**

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -44,6 +44,8 @@ const PLATFORM_ABOUT_COMMAND = 'command:platform.about';
 /**
  * Serialized PAPI request for `ProjectLookupService.getMetadataForAllProjects` (see
  * `network-object.service.ts` `getNetworkObjectRequestType`). Mirrors paranext-core's helpers.
+ * Unlike {@link SERVICE_HOST_OBJECT_METHODS}, this is coupled to both the object id and the method
+ * name; if paranext-core renames either, this stops matching and times out.
  */
 const PROJECT_LOOKUP_GET_ALL_PROJECTS_METHOD =
   'object:ProjectLookupService.getMetadataForAllProjects';

--- a/e2e-tests/fixtures/helpers.ts
+++ b/e2e-tests/fixtures/helpers.ts
@@ -890,6 +890,10 @@ export async function openInterlinearizerFromScriptureEditor(
     if ((await homeTab.count()) === 0) {
       await homeButton.click();
       await expect(homeTab).toBeVisible({ timeout: 10_000 });
+    } else {
+      // Home is already open as a tab. Dispatch a click (not a real click, so an off-viewport tab on
+      // small CI viewports still closes) to guarantee focus before driving its iframe.
+      await homeTab.dispatchEvent('click');
     }
     const homeFrame = page.frameLocator('iframe[title="Home"]');
     // Match the project's own row by its EXACT name (`:text-is()`), not a substring (`:has-text()`),

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -15,10 +15,12 @@ import {
 } from './fixtures/helpers';
 import {
   bootstrapRendererDevServer,
+  DEV_SERVER_PID_FILE,
   isPortInUse,
   waitForPort,
   WEBSOCKET_PORT,
 } from './global-setup';
+import { killProcessFromPidFile } from './global-teardown';
 import { killProcessTree, removeDirWithRetry, waitForProcessExit } from './process-utils';
 
 /**
@@ -122,11 +124,13 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
   console.log(`Loading extension from: ${extensionDist}`);
   console.log(`Remote debugging on port ${CDP_PORT}`);
 
-  // Seed platform.firstRunComplete before launch so paranext-core's first-run wizard overlay does
-  // not gate the app (same seeding the smoke tier does in fixtures/app.fixture.ts). The overlay is a
-  // full-screen modal Dialog that intercepts pointer events, which would block every feature test.
-  // Backed up and restored by globalTeardownCdp after the launched app is killed.
-  seedFirstRunComplete();
+  // Seed E2E_SETTINGS_OVERRIDES before launch — platform.firstRunComplete so paranext-core's
+  // first-run wizard overlay does not gate the app (a full-screen modal Dialog that intercepts
+  // pointer events, which would block every feature test), and platform.interfaceMode so the run
+  // gets the visible, clickable dock-tab layout the suite is written against (same seeding the
+  // smoke tier does in fixtures/app.fixture.ts). Backed up and restored by globalTeardownCdp after
+  // the launched app is killed.
+  seedE2ESettingsOverrides();
 
   // Stream the app's output to a log file rather than discarding it (`stdio: 'ignore'`): when the
   // app crashes on startup the only other symptom is an opaque WebSocket-port timeout below.
@@ -225,6 +229,10 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
     restoreSeededSettings();
     fs.rmSync(CDP_PID_FILE, { force: true });
     fs.rmSync(CDP_USER_DATA_FILE, { force: true });
+    // bootstrapRendererDevServer() above may have started this; Playwright skips globalTeardown on a
+    // thrown globalSetup, so without this it would otherwise leak until the next run's
+    // bootstrapRendererDevServer detects the port in use and reuses it.
+    killProcessFromPidFile(DEV_SERVER_PID_FILE, 'SIGTERM', 'renderer dev server');
     throw error;
   }
   console.log('Platform.Bible (CDP) is ready.');
@@ -322,12 +330,12 @@ function clearStaleOwnershipMarkers(): void {
  *
  * @returns Nothing.
  */
-function seedFirstRunComplete(): void {
+function seedE2ESettingsOverrides(): void {
   backupAndSeedSettings(E2E_SETTINGS_OVERRIDES);
 }
 
 /**
- * Undo {@link seedFirstRunComplete} by restoring the dev-appdata settings file from its on-disk
+ * Undo {@link seedE2ESettingsOverrides} by restoring the dev-appdata settings file from its on-disk
  * backup. A no-op when no backup exists. Best-effort: guarded so a settings-restore failure never
  * aborts teardown.
  *

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -310,8 +310,6 @@ function clearStaleOwnershipMarkers(): void {
  * @returns Nothing.
  */
 function seedFirstRunComplete(): void {
-  // A leftover backup means a prior launched run seeded but never restored; recover its original
-  // first so we don't back up (and later "restore" to) an already-seeded file.
   restoreSeededSettings();
 
   let existing: Record<string, unknown> = {};

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -10,6 +10,7 @@ import {
   E2E_SETTINGS_OVERRIDES,
   restoreBackedUpSettings,
   waitForDockTabTitlesResolved,
+  waitForInterlinearizerReady,
   waitForServiceHostsRegistered,
   withFatalStartupTripwire,
 } from './fixtures/helpers';
@@ -210,7 +211,10 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
     await Promise.race([waitForPort(WEBSOCKET_PORT, APP_READY_TIMEOUT), earlyExit]);
     console.log(`Waiting for CDP debug port ${CDP_PORT}...`);
     await Promise.race([waitForPort(CDP_PORT, APP_READY_TIMEOUT), earlyExit]);
-    console.log('Ports are up. Waiting for the renderer to settle (dock tabs with real titles)...');
+    console.log(
+      'Ports are up. Waiting for the renderer to settle (dock tabs with real titles) and the ' +
+        'interlinearizer extension to activate...',
+    );
     await Promise.race([waitForRendererSettled(RENDERER_SETTLE_TIMEOUT), earlyExit]);
   } catch (error) {
     // The app never came up (or came up broken). Echo its captured output so the cause is in the CI
@@ -240,17 +244,20 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
 
 /**
  * Connect to the launched app over CDP and wait for its renderer to settle: the renderer page
- * exists and the dock tabs have real titles (none stuck at "Unknown"). This is the earliest point
- * at which the tab-title-based locators the feature tests rely on can work, so gating setup on it
- * converts a broken shared instance into one fast, diagnosable setup failure instead of a cascade
- * of per-test timeouts.
+ * exists, the dock tabs have real titles (none stuck at "Unknown"), and the interlinearizer
+ * extension has finished activating (registered `interlinearizer.openForWebView`). This is the
+ * earliest point at which the tab-title-based locators AND the interlinearizer-opening flow that
+ * the feature tests rely on can work.
  *
  * The Playwright connection is closed before returning either way — it only disconnects; the app
  * keeps running for the test fixtures to connect to.
  *
- * @param timeout Maximum time in milliseconds to wait for the renderer page and settled tabs.
- * @returns Resolves when the renderer page shows at least one dock tab and no "Unknown" titles.
- * @throws {Error} If no renderer page appears or tab titles do not resolve within `timeout`.
+ * @param timeout Maximum time in milliseconds to wait for the renderer page, settled tabs, and the
+ *   extension's activation.
+ * @returns Resolves when the renderer page shows at least one dock tab with no "Unknown" titles and
+ *   the interlinearizer extension has registered its open-webview command.
+ * @throws {Error} If no renderer page appears, tab titles do not resolve, or the extension does not
+ *   activate within `timeout`.
  */
 async function waitForRendererSettled(timeout: number): Promise<void> {
   const deadline = Date.now() + timeout;
@@ -293,6 +300,9 @@ async function waitForRendererSettled(timeout: number): Promise<void> {
       await waitForDockTabTitlesResolved(page, budgetLeft(), {
         strict: true,
       });
+      // Also gate on the interlinearizer extension having finished activating. Else, the first
+      // feature test's short per-test budget covers activation it was never sized for.
+      await waitForInterlinearizerReady(budgetLeft());
     });
   } finally {
     // Disconnect only — connectOverCDP close() does not terminate the app.

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -125,12 +125,8 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
   console.log(`Loading extension from: ${extensionDist}`);
   console.log(`Remote debugging on port ${CDP_PORT}`);
 
-  // Seed E2E_SETTINGS_OVERRIDES before launch — platform.firstRunComplete so paranext-core's
-  // first-run wizard overlay does not gate the app (a full-screen modal Dialog that intercepts
-  // pointer events, which would block every feature test), and platform.interfaceMode so the run
-  // gets the visible, clickable dock-tab layout the suite is written against (same seeding the
-  // smoke tier does in fixtures/app.fixture.ts). Backed up and restored by globalTeardownCdp after
-  // the launched app is killed.
+  // Seed E2E_SETTINGS_OVERRIDES before launch and back up settings (restored by globalTeardownCdp
+  // after the launched app is killed).
   seedE2ESettingsOverrides();
 
   // Stream the app's output to a log file rather than discarding it (`stdio: 'ignore'`): when the
@@ -199,9 +195,8 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
   // rejection.
   earlyExit.catch(() => {});
 
-  // Resolves (rather than rejects, unlike earlyExit) once the launched process has actually exited.
-  // Used by the failure-path cleanup below to bound the wait for a just-issued SIGKILL to take effect
-  // before touching files the process may still hold open.
+  // Resolves once the process exits (unlike earlyExit, which rejects). Allows the failure-path
+  // cleanup to bound its wait for a just-issued SIGKILL to take effect.
   const exited = new Promise<void>((resolve) => {
     appProcess.once('exit', () => resolve());
   });
@@ -220,22 +215,20 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
     // The app never came up (or came up broken). Echo its captured output so the cause is in the CI
     // log itself, not only the uploaded artifact.
     dumpAppLog();
-    // Playwright does not run globalTeardown when globalSetup throws, so clean up immediately rather
-    // than leaving the seeded settings and the launched process for the next run's self-heal. Mirrors
-    // globalTeardownCdp's safe ordering (kill first, restore settings last): the still-running app
-    // owns dev-appdata/settings.json, so restoring before it is actually dead risks it flushing the
-    // seeded value back over the just-restored original, with no backup left to recover from.
+    // Playwright does not run globalTeardown when globalSetup throws, so clean up everything this
+    // setup owns right here instead of leaking it to the next run.
     const killed = appProcess.pid ? killProcessTree(appProcess.pid, 'SIGKILL') : false;
     if (killed) {
       await waitForProcessExit(exited, 1_000);
     }
     await removeDirWithRetry(userDataDir, 'CDP user-data dir');
+    // Restore settings after waiting for the kill above to take effect. The still-running app owns
+    // dev-appdata/settings.json, so restoring before it's dead risks flushing the seeded value back
+    // over the just-restored original, with no backup left to recover from.
     restoreSeededSettings();
     fs.rmSync(CDP_PID_FILE, { force: true });
     fs.rmSync(CDP_USER_DATA_FILE, { force: true });
-    // bootstrapRendererDevServer() above may have started this; Playwright skips globalTeardown on a
-    // thrown globalSetup, so without this it would otherwise leak until the next run's
-    // bootstrapRendererDevServer detects the port in use and reuses it.
+    // Also stop the renderer dev server that bootstrapRendererDevServer() may have started.
     killProcessFromPidFile(DEV_SERVER_PID_FILE, 'SIGTERM', 'renderer dev server');
     throw error;
   }
@@ -333,10 +326,8 @@ function clearStaleOwnershipMarkers(): void {
 }
 
 /**
- * Seed {@link E2E_SETTINGS_OVERRIDES} into paranext-core's dev-appdata settings before launching the
- * app (the same seeding the smoke tier does in fixtures/app.fixture.ts). Backs up the original file
- * to disk for {@link restoreSeededSettings} to put back in teardown, self-healing a leftover backup
- * from a prior crashed run of either tier first — see {@link backupAndSeedSettings}.
+ * Seed {@link E2E_SETTINGS_OVERRIDES} before launching the app. Thin wrapper around
+ * {@link backupAndSeedSettings} — see its doc for the backup/self-heal behavior.
  *
  * @returns Nothing.
  */
@@ -345,9 +336,8 @@ function seedE2ESettingsOverrides(): void {
 }
 
 /**
- * Undo {@link seedE2ESettingsOverrides} by restoring the dev-appdata settings file from its on-disk
- * backup. A no-op when no backup exists. Best-effort: guarded so a settings-restore failure never
- * aborts teardown.
+ * Undo {@link seedE2ESettingsOverrides}. Thin wrapper around {@link restoreBackedUpSettings} — see
+ * its doc for the restore/self-heal behavior.
  *
  * @returns Nothing.
  */

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -6,6 +6,7 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {
+  DEV_APPDATA_SETTINGS_PATH,
   waitForDockTabTitlesResolved,
   waitForServiceHostsRegistered,
   withFatalStartupTripwire,
@@ -36,6 +37,15 @@ export const CDP_USER_DATA_FILE = path.join(__dirname, '.cdp-app.user-data-dir')
  * crash leaves a diagnosable log instead of only an opaque WebSocket-port timeout.
  */
 export const CDP_APP_LOG_FILE = path.join(__dirname, '.cdp-app-startup.log');
+
+/**
+ * File the pre-launch dev-appdata settings backup is written to (kept alongside the other `.cdp-*`
+ * markers) so teardown can restore the developer's original settings after the run.
+ */
+const CDP_SETTINGS_BACKUP_FILE = path.join(__dirname, '.cdp-settings-backup');
+
+/** Marker stored in {@link CDP_SETTINGS_BACKUP_FILE} when no settings file existed before seeding. */
+const SETTINGS_ABSENT_SENTINEL = '__SETTINGS_ABSENT__';
 
 /** How long to wait for the launched app's WebSocket / CDP port before failing setup. */
 const APP_READY_TIMEOUT = process.env.CI ? 600_000 : 120_000;
@@ -117,6 +127,12 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
   console.log(`Launching Platform.Bible (CDP) from: ${coreDir}`);
   console.log(`Loading extension from: ${extensionDist}`);
   console.log(`Remote debugging on port ${CDP_PORT}`);
+
+  // Seed platform.firstRunComplete before launch so paranext-core's first-run wizard overlay does
+  // not gate the app (same seeding the smoke tier does in fixtures/app.fixture.ts). The overlay is a
+  // full-screen modal Dialog that intercepts pointer events, which would block every feature test.
+  // Backed up and restored by globalTeardownCdp after the launched app is killed.
+  seedFirstRunComplete();
 
   // Stream the app's output to a log file rather than discarding it (`stdio: 'ignore'`): when the
   // app crashes on startup the only other symptom is an opaque WebSocket-port timeout below.
@@ -262,14 +278,18 @@ async function waitForRendererSettled(timeout: number): Promise<void> {
 }
 
 /**
- * Remove the ownership marker files ({@link CDP_PID_FILE}, {@link CDP_USER_DATA_FILE}) if present.
- * Called from the warm-instance reuse path, where this run owns none of the resources those markers
- * describe, so a stale marker from a prior launched run would make {@link globalTeardownCdp} act on
- * foreign resources. Best-effort: each removal is guarded.
+ * Remove the ownership marker files ({@link CDP_PID_FILE}, {@link CDP_USER_DATA_FILE}) if present and
+ * restore any settings a prior launched run seeded. Called from the warm-instance reuse path, where
+ * this run owns none of the resources those markers describe, so a stale marker from a prior
+ * launched run would make {@link globalTeardownCdp} act on foreign resources (and a stale settings
+ * seed would linger in the developer's dev-appdata). Best-effort: each removal is guarded.
  *
  * @returns Nothing.
  */
 function clearStaleOwnershipMarkers(): void {
+  // Undo any seed a prior launched run left behind before it crashed, so the developer's warm
+  // instance isn't reused with lingering test settings on disk.
+  restoreSeededSettings();
   [CDP_PID_FILE, CDP_USER_DATA_FILE].forEach((markerFile) => {
     try {
       fs.rmSync(markerFile, { force: true });
@@ -277,6 +297,64 @@ function clearStaleOwnershipMarkers(): void {
       console.warn(`Could not remove stale CDP marker ${markerFile}: ${error}`);
     }
   });
+}
+
+/**
+ * Back up paranext-core's dev-appdata settings file and seed `platform.firstRunComplete: true` into
+ * it before launching the app, so the first-run wizard overlay does not gate the launched instance
+ * (the same seeding the smoke tier does in fixtures/app.fixture.ts). The original file is saved to
+ * {@link CDP_SETTINGS_BACKUP_FILE} for {@link restoreSeededSettings} to put back in teardown.
+ * Recovers from a leftover backup first (a prior run that crashed before restoring) so the true
+ * original — not an already-seeded file — is what gets backed up.
+ *
+ * @returns Nothing.
+ */
+function seedFirstRunComplete(): void {
+  // A leftover backup means a prior launched run seeded but never restored; recover its original
+  // first so we don't back up (and later "restore" to) an already-seeded file.
+  restoreSeededSettings();
+
+  let existing: Record<string, unknown> = {};
+  if (fs.existsSync(DEV_APPDATA_SETTINGS_PATH)) {
+    const original = fs.readFileSync(DEV_APPDATA_SETTINGS_PATH, 'utf-8');
+    fs.writeFileSync(CDP_SETTINGS_BACKUP_FILE, original);
+    try {
+      const parsed: unknown = JSON.parse(original);
+      // Preserve existing settings only when the file holds a JSON object; a corrupt or non-object
+      // file falls back to just the override.
+      if (parsed && typeof parsed === 'object') existing = { ...parsed };
+    } catch {
+      // Corrupt file — overwrite with just the override.
+    }
+  } else {
+    // Record absence so teardown deletes the file this run creates rather than leaving it behind.
+    fs.writeFileSync(CDP_SETTINGS_BACKUP_FILE, SETTINGS_ABSENT_SENTINEL);
+  }
+  fs.mkdirSync(path.dirname(DEV_APPDATA_SETTINGS_PATH), { recursive: true });
+  fs.writeFileSync(
+    DEV_APPDATA_SETTINGS_PATH,
+    JSON.stringify({ ...existing, 'platform.firstRunComplete': true }),
+  );
+}
+
+/**
+ * Undo {@link seedFirstRunComplete}: restore the dev-appdata settings file from
+ * {@link CDP_SETTINGS_BACKUP_FILE} (or delete it if the backup marks that no settings file existed
+ * before seeding), then remove the backup marker. A no-op when no backup exists. Best-effort:
+ * guarded so a settings-restore failure never aborts teardown.
+ *
+ * @returns Nothing.
+ */
+export function restoreSeededSettings(): void {
+  if (!fs.existsSync(CDP_SETTINGS_BACKUP_FILE)) return;
+  try {
+    const backup = fs.readFileSync(CDP_SETTINGS_BACKUP_FILE, 'utf-8');
+    if (backup === SETTINGS_ABSENT_SENTINEL) fs.rmSync(DEV_APPDATA_SETTINGS_PATH, { force: true });
+    else fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, backup);
+    fs.rmSync(CDP_SETTINGS_BACKUP_FILE, { force: true });
+  } catch (error) {
+    console.warn(`Could not restore dev-appdata settings after CDP run: ${error}`);
+  }
 }
 
 /**

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -7,6 +7,7 @@ import os from 'os';
 import path from 'path';
 import {
   backupAndSeedSettings,
+  E2E_SETTINGS_OVERRIDES,
   restoreBackedUpSettings,
   waitForDockTabTitlesResolved,
   waitForServiceHostsRegistered,
@@ -314,16 +315,15 @@ function clearStaleOwnershipMarkers(): void {
 }
 
 /**
- * Seed `platform.firstRunComplete: true` into paranext-core's dev-appdata settings before launching
- * the app, so the first-run wizard overlay does not gate the launched instance (the same seeding
- * the smoke tier does in fixtures/app.fixture.ts). Backs up the original file to disk for
- * {@link restoreSeededSettings} to put back in teardown, self-healing a leftover backup from a prior
- * crashed run of either tier first — see {@link backupAndSeedSettings}.
+ * Seed {@link E2E_SETTINGS_OVERRIDES} into paranext-core's dev-appdata settings before launching the
+ * app (the same seeding the smoke tier does in fixtures/app.fixture.ts). Backs up the original file
+ * to disk for {@link restoreSeededSettings} to put back in teardown, self-healing a leftover backup
+ * from a prior crashed run of either tier first — see {@link backupAndSeedSettings}.
  *
  * @returns Nothing.
  */
 function seedFirstRunComplete(): void {
-  backupAndSeedSettings({ 'platform.firstRunComplete': true });
+  backupAndSeedSettings(E2E_SETTINGS_OVERRIDES);
 }
 
 /**

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -9,6 +9,7 @@ import {
   backupAndSeedSettings,
   E2E_SETTINGS_OVERRIDES,
   restoreBackedUpSettings,
+  waitForAtLeastOneProjectMetadata,
   waitForDockTabTitlesResolved,
   waitForInterlinearizerReady,
   waitForServiceHostsRegistered,
@@ -296,6 +297,8 @@ async function waitForRendererSettled(timeout: number): Promise<void> {
       // Also gate on the interlinearizer extension having finished activating. Else, the first
       // feature test's short per-test budget covers activation it was never sized for.
       await waitForInterlinearizerReady(budgetLeft());
+      // Also gate on the bundled WEB project having finished installing.
+      await waitForAtLeastOneProjectMetadata(budgetLeft());
     });
   } finally {
     // Disconnect only — connectOverCDP close() does not terminate the app.

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -6,7 +6,8 @@ import fs from 'fs';
 import os from 'os';
 import path from 'path';
 import {
-  DEV_APPDATA_SETTINGS_PATH,
+  backupAndSeedSettings,
+  restoreBackedUpSettings,
   waitForDockTabTitlesResolved,
   waitForServiceHostsRegistered,
   withFatalStartupTripwire,
@@ -17,6 +18,7 @@ import {
   waitForPort,
   WEBSOCKET_PORT,
 } from './global-setup';
+import { killProcessTree } from './process-utils';
 
 /**
  * Chromium remote-debugging port the self-launched Electron instance exposes and the CDP fixture
@@ -43,9 +45,6 @@ export const CDP_APP_LOG_FILE = path.join(__dirname, '.cdp-app-startup.log');
  * markers) so teardown can restore the developer's original settings after the run.
  */
 const CDP_SETTINGS_BACKUP_FILE = path.join(__dirname, '.cdp-settings-backup');
-
-/** Marker stored in {@link CDP_SETTINGS_BACKUP_FILE} when no settings file existed before seeding. */
-const SETTINGS_ABSENT_SENTINEL = '__SETTINGS_ABSENT__';
 
 /** How long to wait for the launched app's WebSocket / CDP port before failing setup. */
 const APP_READY_TIMEOUT = process.env.CI ? 600_000 : 120_000;
@@ -210,6 +209,15 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
     // The app never came up (or came up broken). Echo its captured output so the cause is in the CI
     // log itself, not only the uploaded artifact.
     dumpAppLog();
+    // Playwright does not run globalTeardown when globalSetup throws, so clean up immediately rather
+    // than leaving the seeded settings and the launched process for the next run's self-heal:
+    // restore the developer's settings, kill the whole launched process tree, and remove the
+    // resources this run owns.
+    restoreSeededSettings();
+    if (appProcess.pid) killProcessTree(appProcess.pid, 'SIGKILL');
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+    fs.rmSync(CDP_PID_FILE, { force: true });
+    fs.rmSync(CDP_USER_DATA_FILE, { force: true });
     throw error;
   }
   console.log('Platform.Bible (CDP) is ready.');
@@ -300,59 +308,28 @@ function clearStaleOwnershipMarkers(): void {
 }
 
 /**
- * Back up paranext-core's dev-appdata settings file and seed `platform.firstRunComplete: true` into
- * it before launching the app, so the first-run wizard overlay does not gate the launched instance
- * (the same seeding the smoke tier does in fixtures/app.fixture.ts). The original file is saved to
- * {@link CDP_SETTINGS_BACKUP_FILE} for {@link restoreSeededSettings} to put back in teardown.
- * Recovers from a leftover backup first (a prior run that crashed before restoring) so the true
- * original — not an already-seeded file — is what gets backed up.
+ * Seed `platform.firstRunComplete: true` into paranext-core's dev-appdata settings before launching
+ * the app, so the first-run wizard overlay does not gate the launched instance (the same seeding
+ * the smoke tier does in fixtures/app.fixture.ts). Backs up the original file to
+ * {@link CDP_SETTINGS_BACKUP_FILE} on disk for {@link restoreSeededSettings} to put back in teardown,
+ * and self-heals a leftover backup from a prior crashed run first — see
+ * {@link backupAndSeedSettings}.
  *
  * @returns Nothing.
  */
 function seedFirstRunComplete(): void {
-  restoreSeededSettings();
-
-  let existing: Record<string, unknown> = {};
-  if (fs.existsSync(DEV_APPDATA_SETTINGS_PATH)) {
-    const original = fs.readFileSync(DEV_APPDATA_SETTINGS_PATH, 'utf-8');
-    fs.writeFileSync(CDP_SETTINGS_BACKUP_FILE, original);
-    try {
-      const parsed: unknown = JSON.parse(original);
-      // Preserve existing settings only when the file holds a JSON object; a corrupt or non-object
-      // file falls back to just the override.
-      if (parsed && typeof parsed === 'object') existing = { ...parsed };
-    } catch {
-      // Corrupt file — overwrite with just the override.
-    }
-  } else {
-    // Record absence so teardown deletes the file this run creates rather than leaving it behind.
-    fs.writeFileSync(CDP_SETTINGS_BACKUP_FILE, SETTINGS_ABSENT_SENTINEL);
-  }
-  fs.mkdirSync(path.dirname(DEV_APPDATA_SETTINGS_PATH), { recursive: true });
-  fs.writeFileSync(
-    DEV_APPDATA_SETTINGS_PATH,
-    JSON.stringify({ ...existing, 'platform.firstRunComplete': true }),
-  );
+  backupAndSeedSettings(CDP_SETTINGS_BACKUP_FILE, { 'platform.firstRunComplete': true });
 }
 
 /**
- * Undo {@link seedFirstRunComplete}: restore the dev-appdata settings file from
- * {@link CDP_SETTINGS_BACKUP_FILE} (or delete it if the backup marks that no settings file existed
- * before seeding), then remove the backup marker. A no-op when no backup exists. Best-effort:
- * guarded so a settings-restore failure never aborts teardown.
+ * Undo {@link seedFirstRunComplete} by restoring the dev-appdata settings file backed up at
+ * {@link CDP_SETTINGS_BACKUP_FILE}. A no-op when no backup exists. Best-effort: guarded so a
+ * settings-restore failure never aborts teardown.
  *
  * @returns Nothing.
  */
 export function restoreSeededSettings(): void {
-  if (!fs.existsSync(CDP_SETTINGS_BACKUP_FILE)) return;
-  try {
-    const backup = fs.readFileSync(CDP_SETTINGS_BACKUP_FILE, 'utf-8');
-    if (backup === SETTINGS_ABSENT_SENTINEL) fs.rmSync(DEV_APPDATA_SETTINGS_PATH, { force: true });
-    else fs.writeFileSync(DEV_APPDATA_SETTINGS_PATH, backup);
-    fs.rmSync(CDP_SETTINGS_BACKUP_FILE, { force: true });
-  } catch (error) {
-    console.warn(`Could not restore dev-appdata settings after CDP run: ${error}`);
-  }
+  restoreBackedUpSettings(CDP_SETTINGS_BACKUP_FILE);
 }
 
 /**

--- a/e2e-tests/global-setup-cdp.ts
+++ b/e2e-tests/global-setup-cdp.ts
@@ -18,7 +18,7 @@ import {
   waitForPort,
   WEBSOCKET_PORT,
 } from './global-setup';
-import { killProcessTree } from './process-utils';
+import { killProcessTree, removeDirWithRetry, waitForProcessExit } from './process-utils';
 
 /**
  * Chromium remote-debugging port the self-launched Electron instance exposes and the CDP fixture
@@ -39,12 +39,6 @@ export const CDP_USER_DATA_FILE = path.join(__dirname, '.cdp-app.user-data-dir')
  * crash leaves a diagnosable log instead of only an opaque WebSocket-port timeout.
  */
 export const CDP_APP_LOG_FILE = path.join(__dirname, '.cdp-app-startup.log');
-
-/**
- * File the pre-launch dev-appdata settings backup is written to (kept alongside the other `.cdp-*`
- * markers) so teardown can restore the developer's original settings after the run.
- */
-const CDP_SETTINGS_BACKUP_FILE = path.join(__dirname, '.cdp-settings-backup');
 
 /** How long to wait for the launched app's WebSocket / CDP port before failing setup. */
 const APP_READY_TIMEOUT = process.env.CI ? 600_000 : 120_000;
@@ -198,6 +192,14 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
   // handled so the eventual teardown kill (same 'exit' event) can't surface as an unhandled
   // rejection.
   earlyExit.catch(() => {});
+
+  // Resolves (rather than rejects, unlike earlyExit) once the launched process has actually exited.
+  // Used by the failure-path cleanup below to bound the wait for a just-issued SIGKILL to take effect
+  // before touching files the process may still hold open.
+  const exited = new Promise<void>((resolve) => {
+    appProcess.once('exit', () => resolve());
+  });
+
   try {
     console.log(`Waiting for PAPI WebSocket on port ${WEBSOCKET_PORT}...`);
     await Promise.race([waitForPort(WEBSOCKET_PORT, APP_READY_TIMEOUT), earlyExit]);
@@ -210,12 +212,16 @@ export default async function globalSetupCdp(_config: FullConfig): Promise<void>
     // log itself, not only the uploaded artifact.
     dumpAppLog();
     // Playwright does not run globalTeardown when globalSetup throws, so clean up immediately rather
-    // than leaving the seeded settings and the launched process for the next run's self-heal:
-    // restore the developer's settings, kill the whole launched process tree, and remove the
-    // resources this run owns.
+    // than leaving the seeded settings and the launched process for the next run's self-heal. Mirrors
+    // globalTeardownCdp's safe ordering (kill first, restore settings last): the still-running app
+    // owns dev-appdata/settings.json, so restoring before it is actually dead risks it flushing the
+    // seeded value back over the just-restored original, with no backup left to recover from.
+    const killed = appProcess.pid ? killProcessTree(appProcess.pid, 'SIGKILL') : false;
+    if (killed) {
+      await waitForProcessExit(exited, 1_000);
+    }
+    await removeDirWithRetry(userDataDir, 'CDP user-data dir');
     restoreSeededSettings();
-    if (appProcess.pid) killProcessTree(appProcess.pid, 'SIGKILL');
-    fs.rmSync(userDataDir, { recursive: true, force: true });
     fs.rmSync(CDP_PID_FILE, { force: true });
     fs.rmSync(CDP_USER_DATA_FILE, { force: true });
     throw error;
@@ -310,26 +316,25 @@ function clearStaleOwnershipMarkers(): void {
 /**
  * Seed `platform.firstRunComplete: true` into paranext-core's dev-appdata settings before launching
  * the app, so the first-run wizard overlay does not gate the launched instance (the same seeding
- * the smoke tier does in fixtures/app.fixture.ts). Backs up the original file to
- * {@link CDP_SETTINGS_BACKUP_FILE} on disk for {@link restoreSeededSettings} to put back in teardown,
- * and self-heals a leftover backup from a prior crashed run first — see
- * {@link backupAndSeedSettings}.
+ * the smoke tier does in fixtures/app.fixture.ts). Backs up the original file to disk for
+ * {@link restoreSeededSettings} to put back in teardown, self-healing a leftover backup from a prior
+ * crashed run of either tier first — see {@link backupAndSeedSettings}.
  *
  * @returns Nothing.
  */
 function seedFirstRunComplete(): void {
-  backupAndSeedSettings(CDP_SETTINGS_BACKUP_FILE, { 'platform.firstRunComplete': true });
+  backupAndSeedSettings({ 'platform.firstRunComplete': true });
 }
 
 /**
- * Undo {@link seedFirstRunComplete} by restoring the dev-appdata settings file backed up at
- * {@link CDP_SETTINGS_BACKUP_FILE}. A no-op when no backup exists. Best-effort: guarded so a
- * settings-restore failure never aborts teardown.
+ * Undo {@link seedFirstRunComplete} by restoring the dev-appdata settings file from its on-disk
+ * backup. A no-op when no backup exists. Best-effort: guarded so a settings-restore failure never
+ * aborts teardown.
  *
  * @returns Nothing.
  */
 export function restoreSeededSettings(): void {
-  restoreBackedUpSettings(CDP_SETTINGS_BACKUP_FILE);
+  restoreBackedUpSettings();
 }
 
 /**

--- a/e2e-tests/global-setup.ts
+++ b/e2e-tests/global-setup.ts
@@ -10,6 +10,13 @@ export const WEBSOCKET_PORT = 8876;
 export const RENDERER_PORT = 1212;
 
 /**
+ * File the renderer dev server's PID is written to, for {@link globalTeardown} to kill it — and for
+ * a CDP setup failure path to kill it too, since Playwright skips `globalTeardown` when
+ * `globalSetup` throws.
+ */
+export const DEV_SERVER_PID_FILE = path.join(__dirname, '.dev-server.pid');
+
+/**
  * Check if a port is already in use.
  *
  * @param port Port number to probe.
@@ -214,9 +221,8 @@ export async function bootstrapRendererDevServer(): Promise<void> {
 
     devServer.unref();
 
-    const pidFile = path.join(extensionRoot, 'e2e-tests/.dev-server.pid');
     if (devServer.pid) {
-      fs.writeFileSync(pidFile, String(devServer.pid));
+      fs.writeFileSync(DEV_SERVER_PID_FILE, String(devServer.pid));
     }
 
     console.log(`Waiting for renderer dev server on port ${RENDERER_PORT}...`);

--- a/e2e-tests/global-teardown-cdp.ts
+++ b/e2e-tests/global-teardown-cdp.ts
@@ -1,7 +1,7 @@
 // Teardown for the self-launching CDP (feature-test) config.
 import type { FullConfig } from '@playwright/test';
 import fs from 'fs';
-import { CDP_PID_FILE, CDP_USER_DATA_FILE } from './global-setup-cdp';
+import { CDP_PID_FILE, CDP_USER_DATA_FILE, restoreSeededSettings } from './global-setup-cdp';
 import globalTeardown, { killProcessFromPidFile } from './global-teardown';
 
 /**
@@ -57,6 +57,11 @@ export default async function globalTeardownCdp(config: FullConfig): Promise<voi
       console.warn(`Could not remove CDP user-data marker ${CDP_USER_DATA_FILE}: ${e}`);
     }
   }
+
+  // Restore the dev-appdata settings this run seeded (see seedFirstRunComplete), now that the app is
+  // dead so its shutdown writes can't clobber the restored file. No-op if nothing was seeded (e.g.
+  // the warm-instance reuse path).
+  restoreSeededSettings();
 
   // Delegate to the shared teardown to stop the renderer dev server and sweep lingering processes.
   await globalTeardown(config);

--- a/e2e-tests/global-teardown-cdp.ts
+++ b/e2e-tests/global-teardown-cdp.ts
@@ -58,9 +58,6 @@ export default async function globalTeardownCdp(config: FullConfig): Promise<voi
     }
   }
 
-  // Restore the dev-appdata settings this run seeded (see seedFirstRunComplete), now that the app is
-  // dead so its shutdown writes can't clobber the restored file. No-op if nothing was seeded (e.g.
-  // the warm-instance reuse path).
   restoreSeededSettings();
 
   // Delegate to the shared teardown to stop the renderer dev server and sweep lingering processes.

--- a/e2e-tests/global-teardown-cdp.ts
+++ b/e2e-tests/global-teardown-cdp.ts
@@ -25,10 +25,9 @@ export default async function globalTeardownCdp(config: FullConfig): Promise<voi
     'self-launched Platform.Bible (CDP) app',
   );
 
-  // Remove the isolated user-data dir created for this run. Give the just-killed Electron a moment
-  // to actually exit and release the SingletonLock before removing (bounded poll — teardown only has
-  // a bare PID, not a live process handle, so it can't listen for 'exit' the way setup does), then
-  // retry once on failure — the smoke teardown removes its dir the same defensive way.
+  // Remove the isolated user-data dir created for this run. Give the just-killed Electron a moment to
+  // actually exit and release the SingletonLock before removing — polling for exit rather than
+  // listening for it, since teardown only has a bare PID, not a live process handle.
   if (fs.existsSync(CDP_USER_DATA_FILE)) {
     const userDataDir = fs.readFileSync(CDP_USER_DATA_FILE, 'utf-8').trim();
     if (userDataDir) {

--- a/e2e-tests/global-teardown-cdp.ts
+++ b/e2e-tests/global-teardown-cdp.ts
@@ -3,6 +3,7 @@ import type { FullConfig } from '@playwright/test';
 import fs from 'fs';
 import { CDP_PID_FILE, CDP_USER_DATA_FILE, restoreSeededSettings } from './global-setup-cdp';
 import globalTeardown, { killProcessFromPidFile } from './global-teardown';
+import { removeDirWithRetry, waitForPidExit } from './process-utils';
 
 /**
  * Playwright global teardown for the CDP config. Kills the Electron instance launched by
@@ -18,35 +19,23 @@ export default async function globalTeardownCdp(config: FullConfig): Promise<voi
   // Kill the app we launched (whole process tree) before the shared teardown's generic sweep.
   // SIGKILL (not SIGTERM): Electron can ignore SIGTERM, and we need it fully dead before removing
   // its user-data dir below.
-  const appKilled = killProcessFromPidFile(
+  const { killed: appKilled, pid: appPid } = killProcessFromPidFile(
     CDP_PID_FILE,
     'SIGKILL',
     'self-launched Platform.Bible (CDP) app',
   );
 
   // Remove the isolated user-data dir created for this run. Give the just-killed Electron a moment
-  // to release the SingletonLock and flush files before removing, then retry once — the smoke
-  // teardown removes its dir the same defensive way.
+  // to actually exit and release the SingletonLock before removing (bounded poll — teardown only has
+  // a bare PID, not a live process handle, so it can't listen for 'exit' the way setup does), then
+  // retry once on failure — the smoke teardown removes its dir the same defensive way.
   if (fs.existsSync(CDP_USER_DATA_FILE)) {
     const userDataDir = fs.readFileSync(CDP_USER_DATA_FILE, 'utf-8').trim();
     if (userDataDir) {
-      if (appKilled) {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 1_000);
-        });
+      if (appKilled && appPid !== undefined) {
+        await waitForPidExit(appPid, 1_000);
       }
-      try {
-        fs.rmSync(userDataDir, { recursive: true, force: true });
-      } catch {
-        await new Promise<void>((resolve) => {
-          setTimeout(resolve, 3_000);
-        });
-        try {
-          fs.rmSync(userDataDir, { recursive: true, force: true });
-        } catch (e) {
-          console.warn(`Could not remove CDP user-data dir ${userDataDir}: ${e}`);
-        }
-      }
+      await removeDirWithRetry(userDataDir, 'CDP user-data dir');
     }
     // Guard the marker removal: an fs error here (locked file on Windows, or the file deleted by a
     // concurrent run between the existsSync above and this unlink) must not abort teardown before

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -3,6 +3,7 @@ import type { FullConfig } from '@playwright/test';
 import { execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
+import { DEV_SERVER_PID_FILE } from './global-setup';
 import { killProcessTree } from './process-utils';
 
 /** Return value of {@link killProcessFromPidFile}. */
@@ -74,12 +75,10 @@ export function killProcessFromPidFile(
  */
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 export default async function globalTeardown(_config: FullConfig): Promise<void> {
-  const extensionRoot = path.resolve(__dirname, '..');
   const coreDir = path.resolve(__dirname, '../../paranext-core');
 
   // Kill the renderer dev server if we started it
-  const pidFile = path.join(extensionRoot, 'e2e-tests', '.dev-server.pid');
-  killProcessFromPidFile(pidFile, 'SIGTERM', 'renderer dev server');
+  killProcessFromPidFile(DEV_SERVER_PID_FILE, 'SIGTERM', 'renderer dev server');
 
   // Run the core stop script to ensure all Electron processes are terminated
   console.log('Running cleanup: npm run stop (in paranext-core)');

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -10,11 +10,7 @@ import { killProcessTree } from './process-utils';
 export interface KillFromPidFileResult {
   /** Whether a valid PID was found and {@link killProcessTree} reported the kill succeeded. */
   killed: boolean;
-  /**
-   * The PID that was targeted, if the file held a valid one — regardless of kill success (a failed
-   * kill means it was already gone). {@link globalTeardownCdp}, the only consumer, reads it only
-   * when `killed` is also true, to poll for the actual process exit (no live handle to listen on).
-   */
+  /** The PID that was targeted, if the file held a valid one — set regardless of kill success. */
   pid?: number;
 }
 

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -11,11 +11,9 @@ export interface KillFromPidFileResult {
   /** Whether a valid PID was found and {@link killProcessTree} reported the kill succeeded. */
   killed: boolean;
   /**
-   * The PID that was targeted, if the file held a valid one — regardless of whether the kill itself
-   * succeeded. Callers that need to poll for the process actually exiting (e.g.
-   * {@link globalTeardownCdp}, which has no live process handle to listen on) need this even when
-   * `killed` is `false` (e.g. `killProcessTree` returning `false` because the process was already
-   * gone).
+   * The PID that was targeted, if the file held a valid one — regardless of kill success (a failed
+   * kill means it was already gone). {@link globalTeardownCdp}, the only consumer, reads it only
+   * when `killed` is also true, to poll for the actual process exit (no live handle to listen on).
    */
   pid?: number;
 }

--- a/e2e-tests/global-teardown.ts
+++ b/e2e-tests/global-teardown.ts
@@ -5,6 +5,20 @@ import path from 'path';
 import fs from 'fs';
 import { killProcessTree } from './process-utils';
 
+/** Return value of {@link killProcessFromPidFile}. */
+export interface KillFromPidFileResult {
+  /** Whether a valid PID was found and {@link killProcessTree} reported the kill succeeded. */
+  killed: boolean;
+  /**
+   * The PID that was targeted, if the file held a valid one — regardless of whether the kill itself
+   * succeeded. Callers that need to poll for the process actually exiting (e.g.
+   * {@link globalTeardownCdp}, which has no live process handle to listen on) need this even when
+   * `killed` is `false` (e.g. `killProcessTree` returning `false` because the process was already
+   * gone).
+   */
+  pid?: number;
+}
+
 /**
  * Kill a process recorded in a PID file (whole tree), then remove the PID file. Shared by this
  * teardown's dev-server kill and {@link globalTeardownCdp}'s launched-app kill, which follow the
@@ -19,34 +33,32 @@ import { killProcessTree } from './process-utils';
  * @param pidFile Absolute path to the file holding the target process's PID.
  * @param signal Kill signal to send (`'SIGKILL'` when the target may ignore SIGTERM).
  * @param label Human-readable name of the process, used in the "Stopping <label>" log line.
- * @returns `true` if a valid PID was found and {@link killProcessTree} reported the kill succeeded;
- *   `false` if the PID file was absent, its contents were not a valid integer, or a filesystem
- *   error occurred.
+ * @returns See {@link KillFromPidFileResult}.
  */
 export function killProcessFromPidFile(
   pidFile: string,
   signal: 'SIGTERM' | 'SIGKILL',
   label: string,
-): boolean {
+): KillFromPidFileResult {
   // Teardown runs once after every worker; a filesystem error here (the PID file deleted by a
   // concurrent run between reads, or locked) must not abort the remaining cleanup (the core stop
   // script) and leak Electron processes. Wrap the whole read → validate → kill → unlink sequence so
   // any such error is logged and swallowed, continuing to return false.
   try {
-    if (!fs.existsSync(pidFile)) return false;
+    if (!fs.existsSync(pidFile)) return { killed: false };
     const pid = parseInt(fs.readFileSync(pidFile, 'utf-8').trim(), 10);
     if (Number.isNaN(pid)) {
       console.warn(`Invalid PID in ${pidFile}, skipping ${label} kill`);
       fs.unlinkSync(pidFile);
-      return false;
+      return { killed: false };
     }
     console.log(`Stopping ${label} (PID: ${pid})...`);
     const killed = killProcessTree(pid, signal);
     fs.unlinkSync(pidFile);
-    return killed;
+    return { killed, pid };
   } catch (e) {
     console.warn(`Failed to kill ${label} from ${pidFile}: ${e}`);
-    return false;
+    return { killed: false };
   }
 }
 

--- a/e2e-tests/process-utils.ts
+++ b/e2e-tests/process-utils.ts
@@ -50,14 +50,11 @@ export function killProcessTree(pid: number, signal: NodeJS.Signals = 'SIGTERM')
 }
 
 /**
- * Race `exitSignal` — a promise that resolves once a LIVE process handle reports its 'exit' event —
- * against `timeoutMs`. For a caller that just sent a kill signal to a process it holds a handle for
- * (an Electron app, a spawned child), this bounds the wait for the process to actually die before
- * touching files it may still hold open (e.g. its user-data dir), without blindly sleeping the full
- * timeout when the process dies sooner.
+ * Bound the wait for a killed process to actually exit without blindly sleeping the full timeout
+ * when it dies sooner. Use before touching files the process may still hold open (e.g. its
+ * user-data dir). Races `exitSignal` (a live process handle's exit event) against `timeoutMs`.
  *
- * For a caller that only has a bare PID (e.g. read from a marker file written by a different
- * process invocation, with no handle to listen on), use {@link waitForPidExit} instead.
+ * For a caller with only a bare PID and no handle to listen on, use {@link waitForPidExit} instead.
  *
  * @param exitSignal Promise that resolves when the process has exited.
  * @param timeoutMs Maximum time in milliseconds to wait before giving up.
@@ -81,16 +78,14 @@ export async function waitForProcessExit(
 }
 
 /**
- * Poll for a PID to stop existing. For a caller with only a bare PID and no live process handle to
- * listen on (see {@link waitForProcessExit} for that case) — e.g. teardown, which reads the PID back
- * from a marker file a separate setup invocation wrote. Signal `0` tests existence without
- * affecting the process; Node (including on Windows) throws once the PID no longer exists.
+ * Poll for a PID to stop existing. This is the {@link waitForProcessExit} equivalent for a caller
+ * with only a bare PID and no live process handle to listen on (e.g. teardown, which reads the PID
+ * back from a marker file a separate setup invocation wrote).
  *
  * @param pid PID to poll.
  * @param timeoutMs Maximum time in milliseconds to wait before giving up.
  * @param pollIntervalMs Milliseconds between existence checks. Defaults to 100.
- * @returns Resolves once the PID no longer exists, or once `timeoutMs` elapses — whichever is
- *   first.
+ * @returns Resolves once the PID no longer exists or `timeoutMs` elapses — whichever is first.
  */
 export async function waitForPidExit(
   pid: number,
@@ -100,6 +95,7 @@ export async function waitForPidExit(
   const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
     try {
+      // Signal 0 is a no-op existence probe — Node throws once the PID no longer exists.
       process.kill(pid, 0);
     } catch {
       return;

--- a/e2e-tests/process-utils.ts
+++ b/e2e-tests/process-utils.ts
@@ -1,5 +1,6 @@
 // Cross-platform process-tree termination, shared by global-teardown.ts and global-teardown-cdp.ts.
 import { execFileSync } from 'child_process';
+import fs from 'fs';
 
 /**
  * Forcibly kill a process and all of its descendants, cross-platform.
@@ -44,6 +45,94 @@ export function killProcessTree(pid: number, signal: NodeJS.Signals = 'SIGTERM')
     } catch {
       // Already stopped
       return false;
+    }
+  }
+}
+
+/**
+ * Race `exitSignal` — a promise that resolves once a LIVE process handle reports its 'exit' event —
+ * against `timeoutMs`. For a caller that just sent a kill signal to a process it holds a handle for
+ * (an Electron app, a spawned child), this bounds the wait for the process to actually die before
+ * touching files it may still hold open (e.g. its user-data dir), without blindly sleeping the full
+ * timeout when the process dies sooner.
+ *
+ * For a caller that only has a bare PID (e.g. read from a marker file written by a different
+ * process invocation, with no handle to listen on), use {@link waitForPidExit} instead.
+ *
+ * @param exitSignal Promise that resolves when the process has exited.
+ * @param timeoutMs Maximum time in milliseconds to wait before giving up.
+ * @returns Resolves once `exitSignal` settles, or once `timeoutMs` elapses — whichever is first.
+ */
+export async function waitForProcessExit(
+  exitSignal: Promise<void>,
+  timeoutMs: number,
+): Promise<void> {
+  await Promise.race([
+    exitSignal,
+    new Promise<void>((resolve) => {
+      setTimeout(resolve, timeoutMs);
+    }),
+  ]);
+}
+
+/**
+ * Poll for a PID to stop existing. For a caller with only a bare PID and no live process handle to
+ * listen on (see {@link waitForProcessExit} for that case) — e.g. teardown, which reads the PID back
+ * from a marker file a separate setup invocation wrote. Signal `0` tests existence without
+ * affecting the process; Node (including on Windows) throws once the PID no longer exists.
+ *
+ * @param pid PID to poll.
+ * @param timeoutMs Maximum time in milliseconds to wait before giving up.
+ * @param pollIntervalMs Milliseconds between existence checks. Defaults to 100.
+ * @returns Resolves once the PID no longer exists, or once `timeoutMs` elapses — whichever is
+ *   first.
+ */
+export async function waitForPidExit(
+  pid: number,
+  timeoutMs: number,
+  pollIntervalMs = 100,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch {
+      return;
+    }
+    // eslint-disable-next-line no-await-in-loop
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, pollIntervalMs);
+    });
+  }
+}
+
+/**
+ * Remove a directory tree, retrying once after a delay if the first attempt fails — e.g. a
+ * just-killed process (Electron's SingletonLock, a Windows file handle) has not yet released it.
+ * Best-effort and non-throwing: a persistent failure is logged, never thrown, so callers can rely
+ * on this never aborting their own cleanup sequence.
+ *
+ * @param dir Directory to remove.
+ * @param label Human-readable name for the directory, used in the warning log if removal ultimately
+ *   fails (e.g. `'user data dir'`, `'CDP user-data dir'`).
+ * @param retryDelayMs Milliseconds to wait before the retry attempt. Defaults to 3000.
+ * @returns Resolves once removal succeeds or the retry attempt is exhausted.
+ */
+export async function removeDirWithRetry(
+  dir: string,
+  label: string,
+  retryDelayMs = 3_000,
+): Promise<void> {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    await new Promise<void>((resolve) => {
+      setTimeout(resolve, retryDelayMs);
+    });
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch (error) {
+      console.warn(`Could not remove ${label} ${dir}: ${error}`);
     }
   }
 }

--- a/e2e-tests/process-utils.ts
+++ b/e2e-tests/process-utils.ts
@@ -67,12 +67,17 @@ export async function waitForProcessExit(
   exitSignal: Promise<void>,
   timeoutMs: number,
 ): Promise<void> {
-  await Promise.race([
-    exitSignal,
-    new Promise<void>((resolve) => {
-      setTimeout(resolve, timeoutMs);
-    }),
-  ]);
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      exitSignal,
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }
 
 /**


### PR DESCRIPTION
This is an e2e-harness-only catch-up fix for recent paranext-core behavior changes, plus reliability hardening for the harness itself. No production/extension code changes.

## Problem

Against current paranext-core, the e2e suite can't reliably reach the dock/Home UI it drives:

- **First-run wizard overlay.** On a fresh profile, when the registration service is unreachable (dev machines and CI), paranext-core renders a full-screen modal ("Couldn't verify your registration") that intercepts pointer events, so every test that drives the toolbar/menus times out behind it.
- **Simple interface mode hides dock tabs.** `platform.interfaceMode` defaults to `'simple'`, which hides the Home/Editor tab bars entirely and populates the Resources column with default tabs that never resolve real titles on a bare e2e profile — breaking both the cold-start readiness gate and the WEB-tab click flow.
- **Fresh profiles now open directly to Home**, not an empty "Scripture Editor" tab as the suite assumed, so the project-opening flow never got far enough to reach it.
- **The bundled sample WEB project installs asynchronously**, independent of dock/extension readiness, so a test could reach Home before it was registered. Most costly on the CDP tier, where one shared instance serves the whole run: losing this race once fails every downstream feature test.

## Fix

**Settings seeding.** `E2E_SETTINGS_OVERRIDES` (`platform.firstRunComplete: true`, `platform.interfaceMode: 'power'`) is written into paranext-core's `dev-appdata/data/settings.json` before Electron launches, in both tiers — the smoke tier's per-worker fixture (`preConfigureSettings()`) and the CDP tier's global setup (`backupAndSeedSettings()`). Forcing Power mode is a stopgap, not a permanent choice — see Follow-up. The original file is backed up to disk (not just in memory) and self-heals a stale backup left by a prior hard-killed run, so a CI timeout or Ctrl+C never loses a developer's real settings; it's restored once the app closes (smoke) or the launched instance is killed (CDP).

**Flexible dock-layout handling.** `openInterlinearizerFromScriptureEditor()` and `ensureInterlinearizerOpenOnWeb()` (`fixtures/helpers.ts`) now accept either starting layout — an empty Scripture Editor tab with no Home tab, or an already-open Home tab — and skip the redundant toolbar Home-button click when Home is already open.

**WEB-project readiness.** `waitForAtLeastOneProjectMetadata()` (mirrors paranext-core's own e2e helper) polls `ProjectLookupService.getMetadataForAllProjects` until a project is registered. It's called inline, right before clicking WEB's row in Home, and also once in the CDP tier's global setup, alongside the interlinearizer extension's own activation gate (`waitForInterlinearizerReady()`). Since the CDP tier launches one shared instance for the whole run, gating setup on both means a broken or slow-starting instance fails setup once with a clear message, instead of every downstream feature test burning its own timeout.

**CDP setup failure-path cleanup.** If any readiness wait throws (ports never open, renderer never settles, extension never activates, project never registers), global setup now kills the launched process tree, removes the isolated user-data dir, restores the seeded settings, and removes its PID/user-data marker files before rethrowing. Playwright skips `globalTeardown` when `globalSetup` throws, so previously all of that leaked to the next run.

**Teardown/process-utility hardening.** Shared helpers in `process-utils.ts` — `waitForProcessExit` (race a live exit event against a timeout), `waitForPidExit` (poll a bare PID for exit, for callers with no live process handle), `removeDirWithRetry` (retry directory removal once after a delay) — replace duplicated one-off sleep/retry logic in both teardown files. `killProcessFromPidFile` now returns `{ killed, pid }` instead of a bare boolean, so callers can wait on that specific PID's exit before touching files it may still hold open.

Full local e2e suite (smoke + CDP) passes against current paranext-core.

## Follow-up

Filed #170 to add real Simple-mode e2e coverage instead of permanently forcing Power mode.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

Devin: https://app.devin.ai/review/sillsdev/interlinearizer-extension/pull/169

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sillsdev/interlinearizer-extension/169)
<!-- Reviewable:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end test startup readiness by waiting for required extension/interlinearizer activation before proceeding.
  * Ensured end-to-end settings overrides are pre-applied before launch and reliably restored afterward, including warm-instance reuse and startup failures.
  * Strengthened failure cleanup with more reliable process-exit waiting, resilient user-data directory removal, and clearer teardown based on PID files.
  * Improved interlinearizer startup handling across differing Home vs Scripture Editor layouts.

* **Chores**
  * Updated ignore rules for end-to-end settings backup artifacts.
  * Standardized dev-server PID handling and teardown results for consistent cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
